### PR TITLE
Add tap-based staff symbol selection and MusicXML/JSON import

### DIFF
--- a/lib/core/widgets/score_notation/score_notation_painter.dart
+++ b/lib/core/widgets/score_notation/score_notation_painter.dart
@@ -6,6 +6,7 @@ import '../../models/key_signature.dart';
 import '../../models/measure.dart';
 import '../../models/note.dart';
 import '../../models/rest.dart';
+import '../../models/score_symbol.dart';
 import '../../models/time_signature.dart';
 import 'staff_pitch_mapper.dart';
 
@@ -17,6 +18,8 @@ class ScoreNotationPainter extends CustomPainter {
     required this.rowHeight,
     required this.padding,
     required this.rowPrefixWidth,
+    this.selectedMeasureIndex,
+    this.selectedSymbolIndex,
   });
 
   final List<Measure> measures;
@@ -25,8 +28,11 @@ class ScoreNotationPainter extends CustomPainter {
   final double rowHeight;
   final EdgeInsets padding;
   final double rowPrefixWidth;
+  final int? selectedMeasureIndex;
+  final int? selectedSymbolIndex;
 
   static const double staffLineSpacing = 12;
+  static const double tapTargetSize = 24;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -37,17 +43,31 @@ class ScoreNotationPainter extends CustomPainter {
   }
 
   List<_RowMetrics> _buildRowMetrics() {
+    return _buildRowMetricsStatic(
+      measures: measures,
+      measuresPerRow: measuresPerRow,
+      rowHeight: rowHeight,
+      padding: padding,
+      rowPrefixWidth: rowPrefixWidth,
+      minMeasureWidth: minMeasureWidth,
+    );
+  }
+
+  static List<_RowMetrics> _buildRowMetricsStatic({
+    required List<Measure> measures,
+    required int measuresPerRow,
+    required double rowHeight,
+    required EdgeInsets padding,
+    required double rowPrefixWidth,
+    required double minMeasureWidth,
+  }) {
     final rows = <_RowMetrics>[];
     final rowCount = (measures.length / measuresPerRow).ceil();
 
     for (var rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       final rowStartMeasure = rowIndex * measuresPerRow;
-      final rowEndExclusive = math.min(
-        rowStartMeasure + measuresPerRow,
-        measures.length,
-      );
+      final rowEndExclusive = math.min(rowStartMeasure + measuresPerRow, measures.length);
       final rowMeasures = measures.sublist(rowStartMeasure, rowEndExclusive);
-
       final rowTop = padding.top + rowIndex * rowHeight + 28;
       final staffTop = rowTop;
       final staffBottom = staffTop + staffLineSpacing * 4;
@@ -58,6 +78,7 @@ class ScoreNotationPainter extends CustomPainter {
       rows.add(
         _RowMetrics(
           rowIndex: rowIndex,
+          globalStartMeasureIndex: rowStartMeasure,
           measures: rowMeasures,
           staffTop: staffTop,
           staffBottom: staffBottom,
@@ -69,6 +90,80 @@ class ScoreNotationPainter extends CustomPainter {
     }
 
     return rows;
+  }
+
+  static List<NotationSymbolTarget> buildSymbolTargets({
+    required List<Measure> measures,
+    required int measuresPerRow,
+    required double minMeasureWidth,
+    required double rowHeight,
+    required EdgeInsets padding,
+    required double rowPrefixWidth,
+  }) {
+    final rows = _buildRowMetricsStatic(
+      measures: measures,
+      measuresPerRow: measuresPerRow,
+      rowHeight: rowHeight,
+      padding: padding,
+      rowPrefixWidth: rowPrefixWidth,
+      minMeasureWidth: minMeasureWidth,
+    );
+    final targets = <NotationSymbolTarget>[];
+
+    for (final row in rows) {
+      for (var measureInRow = 0; measureInRow < row.measures.length; measureInRow++) {
+        final measure = row.measures[measureInRow];
+        final measureStartX = row.contentStartX + (measureInRow * minMeasureWidth);
+        final measureEndX = measureStartX + minMeasureWidth;
+        if (measure.symbols.isEmpty) continue;
+
+        const innerPadding = 16.0;
+        final drawableWidth = math.max(
+          12.0,
+          (measureEndX - measureStartX) - (innerPadding * 2),
+        );
+
+        for (var symbolIndex = 0; symbolIndex < measure.symbols.length; symbolIndex++) {
+          final symbol = measure.symbols[symbolIndex];
+          final progress = (symbolIndex + 1) / (measure.symbols.length + 1);
+          final x = measureStartX + innerPadding + (drawableWidth * progress);
+          final y = _symbolCenterY(symbol, row.staffTop, row.staffBottom);
+          targets.add(
+            NotationSymbolTarget(
+              measureIndex: row.globalStartMeasureIndex + measureInRow,
+              symbolIndex: symbolIndex,
+              center: Offset(x, y),
+              hitRect: Rect.fromCenter(
+                center: Offset(x, y),
+                width: tapTargetSize,
+                height: tapTargetSize,
+              ),
+            ),
+          );
+        }
+      }
+    }
+    return targets;
+  }
+
+  static double _symbolCenterY(ScoreSymbol symbol, double staffTop, double staffBottom) {
+    if (symbol is Note) {
+      return StaffPitchMapper.yForPitch(
+        step: symbol.step,
+        octave: symbol.octave,
+        bottomLineY: staffBottom,
+        lineSpacing: staffLineSpacing,
+      );
+    }
+
+    final restType = symbol is Rest ? symbol.type.trim().toLowerCase() : '';
+    if (restType == 'whole') {
+      return staffTop + (staffLineSpacing * 3) + 4.3;
+    }
+    if (restType == 'half') {
+      return staffTop + (staffLineSpacing * 2) - 3.0;
+    }
+    return staffTop + (staffLineSpacing * 1.35) + 8.0;
   }
 
   void _drawRow(Canvas canvas, _RowMetrics row) {
@@ -199,11 +294,31 @@ class ScoreNotationPainter extends CustomPainter {
           bottomLineY: staffBottom,
           lineSpacing: staffLineSpacing,
         );
+        final isSelected =
+            selectedMeasureIndex == row.globalStartMeasureIndex + measureInRow &&
+            selectedSymbolIndex == i;
+        if (isSelected) {
+          _drawSelectionHighlight(canvas, Offset(x, y));
+        }
         _drawNote(canvas, symbol, x: x, y: y, middleLineY: middleLineY);
       } else if (symbol is Rest) {
+        final y = _symbolCenterY(symbol, staffTop, staffBottom);
+        final isSelected =
+            selectedMeasureIndex == row.globalStartMeasureIndex + measureInRow &&
+            selectedSymbolIndex == i;
+        if (isSelected) {
+          _drawSelectionHighlight(canvas, Offset(x, y));
+        }
         _drawRest(canvas, symbol, x: x, staffTop: staffTop);
       }
     }
+  }
+
+  void _drawSelectionHighlight(Canvas canvas, Offset center) {
+    final paint = Paint()
+      ..color = const Color(0xFFD4A96A).withValues(alpha: 0.26)
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(center, 14, paint);
   }
 
   void _drawNote(
@@ -486,13 +601,30 @@ class ScoreNotationPainter extends CustomPainter {
         oldDelegate.minMeasureWidth != minMeasureWidth ||
         oldDelegate.rowHeight != rowHeight ||
         oldDelegate.padding != padding ||
-        oldDelegate.rowPrefixWidth != rowPrefixWidth;
+        oldDelegate.rowPrefixWidth != rowPrefixWidth ||
+        oldDelegate.selectedMeasureIndex != selectedMeasureIndex ||
+        oldDelegate.selectedSymbolIndex != selectedSymbolIndex;
   }
+}
+
+class NotationSymbolTarget {
+  const NotationSymbolTarget({
+    required this.measureIndex,
+    required this.symbolIndex,
+    required this.center,
+    required this.hitRect,
+  });
+
+  final int measureIndex;
+  final int symbolIndex;
+  final Offset center;
+  final Rect hitRect;
 }
 
 class _RowMetrics {
   const _RowMetrics({
     required this.rowIndex,
+    required this.globalStartMeasureIndex,
     required this.measures,
     required this.staffTop,
     required this.staffBottom,
@@ -502,6 +634,7 @@ class _RowMetrics {
   });
 
   final int rowIndex;
+  final int globalStartMeasureIndex;
   final List<Measure> measures;
   final double staffTop;
   final double staffBottom;

--- a/lib/core/widgets/score_notation_viewer.dart
+++ b/lib/core/widgets/score_notation_viewer.dart
@@ -19,6 +19,9 @@ class ScoreNotationViewer extends StatefulWidget {
     this.rowHeight = 140,
     this.padding = const EdgeInsets.all(16),
     this.backgroundColor = const Color(0xFFF9FAFB),
+    this.selectedMeasureIndex,
+    this.selectedSymbolIndex,
+    this.onSymbolTap,
   });
 
   final Score? score;
@@ -27,6 +30,9 @@ class ScoreNotationViewer extends StatefulWidget {
   final double rowHeight;
   final EdgeInsets padding;
   final Color backgroundColor;
+  final int? selectedMeasureIndex;
+  final int? selectedSymbolIndex;
+  final ValueChanged<NotationSymbolTarget?>? onSymbolTap;
 
   @override
   State<ScoreNotationViewer> createState() => _ScoreNotationViewerState();
@@ -63,6 +69,24 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
       backgroundColor: widget.backgroundColor,
       horizontalController: _horizontalController,
       size: layout.size,
+      onTapUp: widget.onSymbolTap == null
+          ? null
+          : (position) {
+              final adjusted = position.translate(
+                _horizontalController.hasClients ? _horizontalController.offset : 0,
+                0,
+              );
+              final targets = ScoreNotationPainter.buildSymbolTargets(
+                measures: measures,
+                measuresPerRow: layout.measuresPerRow,
+                minMeasureWidth: widget.minMeasureWidth,
+                rowHeight: widget.rowHeight,
+                padding: widget.padding,
+                rowPrefixWidth: layout.rowPrefixWidth,
+              );
+              final tapped = _nearestTarget(adjusted, targets);
+              widget.onSymbolTap?.call(tapped);
+            },
       painter: ScoreNotationPainter(
         measures: measures,
         measuresPerRow: layout.measuresPerRow,
@@ -70,8 +94,27 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
         rowHeight: widget.rowHeight,
         padding: widget.padding,
         rowPrefixWidth: layout.rowPrefixWidth,
+        selectedMeasureIndex: widget.selectedMeasureIndex,
+        selectedSymbolIndex: widget.selectedSymbolIndex,
       ),
     );
+  }
+
+  NotationSymbolTarget? _nearestTarget(
+    Offset position,
+    List<NotationSymbolTarget> targets,
+  ) {
+    NotationSymbolTarget? best;
+    double? bestDistance;
+    for (final target in targets) {
+      if (!target.hitRect.contains(position)) continue;
+      final distance = (target.center - position).distanceSquared;
+      if (best == null || distance < bestDistance!) {
+        best = target;
+        bestDistance = distance;
+      }
+    }
+    return best;
   }
 
   List<Measure> _measuresFor(Score? score) {
@@ -86,12 +129,14 @@ class _NotationCanvasFrame extends StatelessWidget {
     required this.horizontalController,
     required this.size,
     required this.painter,
+    this.onTapUp,
   });
 
   final Color backgroundColor;
   final ScrollController horizontalController;
   final Size size;
   final CustomPainter painter;
+  final ValueChanged<Offset>? onTapUp;
 
   @override
   Widget build(BuildContext context) {
@@ -101,10 +146,14 @@ class _NotationCanvasFrame extends StatelessWidget {
         borderRadius: BorderRadius.circular(10),
         border: Border.all(color: const Color(0xFFE5E7EB)),
       ),
-      child: SingleChildScrollView(
-        controller: horizontalController,
-        scrollDirection: Axis.horizontal,
-        child: CustomPaint(size: size, painter: painter),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTapUp: onTapUp == null ? null : (details) => onTapUp!(details.localPosition),
+        child: SingleChildScrollView(
+          controller: horizontalController,
+          scrollDirection: Axis.horizontal,
+          child: CustomPaint(size: size, painter: painter),
+        ),
       ),
     );
   }

--- a/lib/features/editor/domain/editor_actions.dart
+++ b/lib/features/editor/domain/editor_actions.dart
@@ -135,24 +135,13 @@ extension EditorActions on EditorState {
       symbols: symbols,
     );
 
-    if (symbols.isEmpty) {
-      return applyEdit(
-        score: nextScore,
-        selectedPartIndex: null,
-        selectedMeasureIndex: null,
-        selectedSymbolIndex: null,
-        selectedSymbol: null,
-        clearSelection: true,
-      );
-    }
-
-    final nextIndex = symbolIndex.clamp(0, symbols.length - 1);
     return applyEdit(
       score: nextScore,
-      selectedPartIndex: partIndex,
-      selectedMeasureIndex: measureIndex,
-      selectedSymbolIndex: nextIndex,
-      selectedSymbol: symbols[nextIndex],
+      selectedPartIndex: null,
+      selectedMeasureIndex: null,
+      selectedSymbolIndex: null,
+      selectedSymbol: null,
+      clearSelection: true,
     );
   }
 

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -41,6 +41,35 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
     });
   }
 
+  void _onNotationSymbolTap(int measureIndex, int symbolIndex) {
+    _updateState((state) {
+      final isSameSelection =
+          state.selectedPartIndex == 0 &&
+          state.selectedMeasureIndex == measureIndex &&
+          state.selectedSymbolIndex == symbolIndex;
+
+      if (isSameSelection) {
+        return state.copyWith(clearSelection: true);
+      }
+
+      final parts = state.score.parts;
+      if (parts.isEmpty || measureIndex < 0 || measureIndex >= parts.first.measures.length) {
+        return state.copyWith(clearSelection: true);
+      }
+      final symbols = parts.first.measures[measureIndex].symbols;
+      if (symbolIndex < 0 || symbolIndex >= symbols.length) {
+        return state.copyWith(clearSelection: true);
+      }
+
+      return state.copyWith(
+        selectedPartIndex: 0,
+        selectedMeasureIndex: measureIndex,
+        selectedSymbolIndex: symbolIndex,
+        selectedSymbol: symbols[symbolIndex],
+      );
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final selected = _editorState.selectedSymbol;
@@ -69,7 +98,18 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                     child: SingleChildScrollView(
                       child: Padding(
                         padding: const EdgeInsets.only(bottom: 12),
-                        child: ScoreNotationViewer(score: _editorState.score),
+                        child: ScoreNotationViewer(
+                          score: _editorState.score,
+                          selectedMeasureIndex: _editorState.selectedMeasureIndex,
+                          selectedSymbolIndex: _editorState.selectedSymbolIndex,
+                          onSymbolTap: (target) {
+                            if (target == null) {
+                              _updateState((state) => state.copyWith(clearSelection: true));
+                              return;
+                            }
+                            _onNotationSymbolTap(target.measureIndex, target.symbolIndex);
+                          },
+                        ),
                       ),
                     ),
                   ),

--- a/lib/features/scan/presentation/scan_screen.dart
+++ b/lib/features/scan/presentation/scan_screen.dart
@@ -1,13 +1,20 @@
 import 'dart:typed_data';
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:provider/provider.dart';
+import 'package:note_vision/core/models/note.dart';
 import 'package:note_vision/core/models/measure.dart';
 import 'package:note_vision/core/models/part.dart';
+import 'package:note_vision/core/models/rest.dart';
 import 'package:note_vision/core/models/score.dart';
+import 'package:note_vision/core/models/score_symbol.dart';
 import 'package:note_vision/core/theme/app_theme.dart';
 import 'package:note_vision/core/theme/responsive_layout.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
 import 'package:note_vision/features/editor/presentation/editor_shell_screen.dart';
+import 'package:note_vision/features/musicXML/musicxml_parser_service.dart';
+import 'package:note_vision/features/musicXML/musicxml_score_converter.dart';
 import 'package:note_vision/features/detection/data/tflite_symbol_detector.dart';
 import 'package:note_vision/features/preprocessing/data/basic_image_preprocessor.dart';
 import 'package:note_vision/features/scan/presentation/scan_viewmodel.dart';
@@ -25,6 +32,9 @@ class ScanScreen extends StatefulWidget {
 }
 
 class _ScanScreenState extends State<ScanScreen> {
+  static const _xmlParser = MusicXmlParserService();
+  static const _xmlConverter = MusicXmlScoreConverter();
+
   @override
   void initState() {
     super.initState();
@@ -58,6 +68,13 @@ class _ScanScreenState extends State<ScanScreen> {
           ),
         ),
         centerTitle: true,
+        actions: [
+          IconButton(
+            tooltip: 'Import MusicXML/JSON',
+            onPressed: _importFromFile,
+            icon: const Icon(Icons.file_upload_outlined),
+          ),
+        ],
       ),
       body: switch (vm.state) {
         ScanState.idle         => const SizedBox(),
@@ -94,6 +111,7 @@ class _ScanScreenState extends State<ScanScreen> {
               padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
               child: ScanActions(
           onRedo: () => Navigator.pop(context),
+          onImport: _importFromFile,
           onContinue: () {
             final mappedScore = vm.mappingResult?.score ??
                 const Score(
@@ -123,6 +141,147 @@ class _ScanScreenState extends State<ScanScreen> {
           ],
         );
       },
+    );
+  }
+
+  Future<void> _importFromFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowMultiple: false,
+      withData: true,
+      allowedExtensions: const ['json', 'xml', 'musicxml'],
+    );
+
+    if (!mounted || result == null || result.files.isEmpty) return;
+    final file = result.files.single;
+    final fileName = file.name;
+    final ext = fileName.split('.').last.toLowerCase();
+    final data = file.bytes;
+    if (data == null) {
+      _showImportError('Unable to read "$fileName".');
+      return;
+    }
+
+    try {
+      final importedScore = switch (ext) {
+        'json' => _scoreFromJson(utf8.decode(data)),
+        'xml' || 'musicxml' => _scoreFromMusicXml(utf8.decode(data)),
+        _ => throw const FormatException('Unsupported import type.'),
+      };
+      if (!mounted) return;
+      Navigator.pushNamed(
+        context,
+        EditorShellScreen.routeName,
+        arguments: EditorShellArgs(
+          score: importedScore,
+          initialState: EditorState(score: importedScore),
+        ),
+      );
+    } catch (_) {
+      _showImportError(
+        'Could not import "$fileName". Use a valid MusicXML or score JSON file.',
+      );
+    }
+  }
+
+  Score _scoreFromMusicXml(String content) {
+    final parsed = _xmlParser.parse(content);
+    if (!parsed.success || parsed.document == null) {
+      throw const FormatException('Invalid MusicXML');
+    }
+    return _xmlConverter.convert(parsed.document!);
+  }
+
+  Score _scoreFromJson(String content) {
+    final root = jsonDecode(content);
+    if (root is! Map) {
+      throw const FormatException('JSON root must be an object');
+    }
+    final rootMap = Map<String, dynamic>.from(root);
+
+    final partMaps = (rootMap['parts'] as List?)
+            ?.whereType<Map>()
+            .map((part) => Map<String, dynamic>.from(part))
+            .toList() ??
+        [];
+    if (partMaps.isEmpty) {
+      throw const FormatException('Score JSON must include parts');
+    }
+
+    final parts = partMaps.map((part) {
+      final measureMaps = (part['measures'] as List?)
+              ?.whereType<Map>()
+              .map((measure) => Map<String, dynamic>.from(measure))
+              .toList() ??
+          [];
+      return Part(
+        id: (part['id']?.toString().isNotEmpty ?? false) ? part['id'].toString() : 'P1',
+        name: part['name']?.toString() ?? 'Part 1',
+        measures: measureMaps.map(_measureFromJson).toList(),
+      );
+    }).toList();
+
+    return Score(
+      id: rootMap['id']?.toString() ?? 'imported-score',
+      title: rootMap['title']?.toString() ?? 'Imported Score',
+      composer: rootMap['composer']?.toString() ?? 'Unknown',
+      parts: parts,
+    );
+  }
+
+  Measure _measureFromJson(Map<String, dynamic> measure) {
+    final symbolMaps = (measure['symbols'] as List?)
+            ?.whereType<Map>()
+            .map((symbol) => Map<String, dynamic>.from(symbol))
+            .toList() ??
+        [];
+    return Measure(
+      number: (measure['number'] as num?)?.toInt() ?? 1,
+      symbols: symbolMaps.map(_symbolFromJson).toList(),
+    );
+  }
+
+  ScoreSymbol _symbolFromJson(Map<String, dynamic> symbol) {
+    final type = symbol['type']?.toString().toLowerCase();
+    if (type == 'rest') {
+      return Rest(
+        duration: (symbol['duration'] as num?)?.toInt() ?? 1,
+        type: symbol['restType']?.toString() ?? symbol['noteType']?.toString() ?? 'quarter',
+        voice: (symbol['voice'] as num?)?.toInt(),
+        staff: (symbol['staff'] as num?)?.toInt(),
+      );
+    }
+
+    final pitch = symbol['pitch']?.toString().toUpperCase() ?? 'C4';
+    final match = RegExp(r'^([A-G])([#B]*)(\d)$').firstMatch(pitch);
+    final step = match?.group(1) ?? symbol['step']?.toString().toUpperCase() ?? 'C';
+    final accidental = match?.group(2) ?? '';
+    final alter = accidental.isEmpty
+        ? (symbol['alter'] as num?)?.toInt()
+        : accidental.replaceAll('B', 'b').split('').fold<int>(
+            0,
+            (value, c) => value + (c == '#' ? 1 : c == 'b' ? -1 : 0),
+          );
+    final octave = int.tryParse(match?.group(3) ?? '') ?? (symbol['octave'] as num?)?.toInt() ?? 4;
+
+    return Note(
+      step: step,
+      octave: octave,
+      alter: alter,
+      duration: (symbol['duration'] as num?)?.toInt() ?? 1,
+      type: symbol['noteType']?.toString() ?? symbol['typeName']?.toString() ?? 'quarter',
+      voice: (symbol['voice'] as num?)?.toInt(),
+      staff: (symbol['staff'] as num?)?.toInt(),
+    );
+  }
+
+  void _showImportError(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        behavior: SnackBarBehavior.floating,
+      ),
     );
   }
 
@@ -245,7 +404,6 @@ class _PipelineStatus extends StatelessWidget {
 
   static const _accent        = Color(0xFFD4A96A);
   static const _surface       = Color(0xFF1A1A1A);
-  static const _textPrimary   = Color(0xFFFFFFFF);
   static const _textSecondary = Color(0xFF8A8A8A);
 
   @override

--- a/lib/features/scan/presentation/widgets/scan_actions.dart
+++ b/lib/features/scan/presentation/widgets/scan_actions.dart
@@ -3,11 +3,13 @@ import 'package:flutter/material.dart';
 class ScanActions extends StatelessWidget {
   final VoidCallback onRedo;
   final VoidCallback onContinue;
+  final VoidCallback? onImport;
 
   const ScanActions({
     super.key,
     required this.onRedo,
     required this.onContinue,
+    this.onImport,
   });
 
   // ── Design tokens ──────────────────────────────────────────────────────────
@@ -60,10 +62,42 @@ class ScanActions extends StatelessWidget {
           ),
 
           const SizedBox(width: 12),
+          if (onImport != null) ...[
+            Expanded(
+              child: _TappableButton(
+                onPressed: onImport!,
+                child: Container(
+                  height: 52,
+                  decoration: BoxDecoration(
+                    color: _surface,
+                    borderRadius: BorderRadius.circular(14),
+                    border: Border.all(color: _border),
+                  ),
+                  child: const Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.file_upload_outlined, size: 18, color: _textMuted),
+                      SizedBox(width: 8),
+                      Text(
+                        'Import',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w400,
+                          color: _textMuted,
+                          letterSpacing: 0.3,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+          ],
 
           // ── Continue (primary) ───────────────────────────────────────
           Expanded(
-            flex: 2,
+            flex: onImport == null ? 2 : 1,
             child: _TappableButton(
               onPressed: onContinue,
               child: Container(

--- a/test/core/widgets/score_notation_viewer_test.dart
+++ b/test/core/widgets/score_notation_viewer_test.dart
@@ -123,5 +123,52 @@ void main() {
       expect(find.byType(ScoreNotationViewer), findsOneWidget);
       expect(tester.takeException(), isNull);
     });
+
+    testWidgets('taps resolve note and rest targets with 24dp hit areas', (
+      tester,
+    ) async {
+      final score = Score(
+        id: 'tap-targets',
+        title: 'Tap targets',
+        composer: 'Tester',
+        parts: [
+          Part(
+            id: 'P1',
+            name: 'Part 1',
+            measures: [
+              Measure(
+                number: 1,
+                symbols: const [
+                  Note(step: 'E', octave: 4, duration: 1, type: 'quarter'),
+                  Rest(duration: 1, type: 'quarter'),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final taps = <(int, int)>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ScoreNotationViewer(
+              score: score,
+              onSymbolTap: (target) {
+                if (target == null) return;
+                taps.add((target.measureIndex, target.symbolIndex));
+              },
+            ),
+          ),
+        ),
+      );
+
+      final origin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+      await tester.tapAt(origin + const Offset(154, 68));
+      await tester.tapAt(origin + const Offset(190, 68));
+      await tester.pump();
+
+      expect(taps, equals([(0, 0), (0, 1)]));
+    });
   });
 }

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:note_vision/core/models/measure.dart';
 import 'package:note_vision/core/models/note.dart';
 import 'package:note_vision/core/models/part.dart';
+import 'package:note_vision/core/models/rest.dart';
 import 'package:note_vision/core/models/score.dart';
+import 'package:note_vision/core/widgets/score_notation_viewer.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
 import 'package:note_vision/features/editor/presentation/editor_shell_screen.dart';
 
@@ -23,6 +25,7 @@ void main() {
               symbols: withSymbols
                   ? const [
                       Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+                      Rest(duration: 1, type: 'quarter'),
                     ]
                   : const [],
             ),
@@ -96,5 +99,41 @@ void main() {
     expect(find.text('C4'), findsOneWidget);
     expect(find.text('quarter'), findsOneWidget);
     expect(find.text('1'), findsOneWidget);
+  });
+
+  testWidgets('tapping symbols selects, reselects, and deselects', (tester) async {
+    final score = buildScore();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+
+    final moveUpButtonFinder = find.widgetWithText(OutlinedButton, 'Move Up');
+    expect(tester.widget<OutlinedButton>(moveUpButtonFinder).onPressed, isNull);
+
+    final notationOrigin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+
+    await tester.tapAt(notationOrigin + const Offset(154, 68));
+    await tester.pump();
+    expect(find.text('Note'), findsOneWidget);
+    expect(find.text('C4'), findsOneWidget);
+    expect(tester.widget<OutlinedButton>(moveUpButtonFinder).onPressed, isNotNull);
+
+    await tester.tapAt(notationOrigin + const Offset(190, 68));
+    await tester.pump();
+    expect(find.text('Rest'), findsOneWidget);
+    expect(find.text('—'), findsWidgets);
+
+    await tester.tapAt(notationOrigin + const Offset(190, 68));
+    await tester.pump();
+    expect(find.text('None'), findsOneWidget);
+    expect(tester.widget<OutlinedButton>(moveUpButtonFinder).onPressed, isNull);
   });
 }


### PR DESCRIPTION
### Motivation
- Enable tapping notes and rests in the notation viewer as a prerequisite for editor edit actions and to provide visible selection feedback. 
- Ensure selection semantics are simple: single selection, toggle deselect on same tap, and safe clearing on delete. 
- Provide a direct import path so users can open MusicXML or JSON score files into the editor (in addition to image detection). 

### Description
- Added hit-target geometry and selection highlighting to the notation painter by computing `NotationSymbolTarget` entries with a 24×24dp `tapTargetSize` and a `_drawSelectionHighlight` circle in `ScoreNotationPainter` (`lib/core/widgets/score_notation/score_notation_painter.dart`). 
- Wrapped the notation canvas with a `GestureDetector` and added `ScoreNotationViewer.onSymbolTap` to translate tap coordinates into the nearest `NotationSymbolTarget` (`lib/core/widgets/score_notation_viewer.dart`). 
- Wired taps into the editor: `EditorShellScreen` now selects, replaces, or clears selection via `_onNotationSymbolTap` and passes selected indices into the viewer for highlighting (`lib/features/editor/presentation/editor_shell_screen.dart`). 
- Made deletion of a selected symbol clear the selection safely (no automatic reselection) in `deleteSelectedSymbol` (`lib/features/editor/domain/editor_actions.dart`). 
- Added a Scan UI import entrypoint (app bar button and optional footer `Import` action) that picks `xml`, `musicxml`, or `json` files, parses MusicXML via existing parser, or converts minimal score JSON into `Score` models and opens the editor (`lib/features/scan/presentation/scan_screen.dart`, `lib/features/scan/presentation/widgets/scan_actions.dart`). 
- Removed an unused color constant (`_textPrimary`) from the pipeline status widget in `scan_screen.dart`. 
- Added widget tests for hit-target tapping (`test/core/widgets/score_notation_viewer_test.dart`) and editor symbol selection/deselection behavior (`test/features/editor/presentation/editor_shell_screen_test.dart`). 

### Testing
- Ran `git diff --check` to validate whitespace/diff issues and committed the changes successfully. 
- Attempted to run `dart format` on modified files, but the environment lacks the `dart`/Flutter toolchain so formatting and test execution could not be performed here (tooling unavailable). 
- New widget tests were added (`score_notation_viewer_test.dart` and `editor_shell_screen_test.dart`) but were not executed in this environment due to missing SDK binaries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c75c388aa4832093dbcdc840591b4f)