### PR TITLE
Require measure context for insert actions, append symbols to measure, fix selection indexing and duration no-op

### DIFF
--- a/lib/core/widgets/score_notation/score_notation_painter.dart
+++ b/lib/core/widgets/score_notation/score_notation_painter.dart
@@ -256,6 +256,7 @@ class ScoreNotationPainter extends CustomPainter {
       _drawMeasureSymbols(
         canvas,
         measure,
+        absoluteMeasureIndex: row.globalStartMeasureIndex + measureInRow,
         measureStartX: measureX,
         measureEndX: nextMeasureX,
         staffTop: row.staffTop,
@@ -267,6 +268,7 @@ class ScoreNotationPainter extends CustomPainter {
   void _drawMeasureSymbols(
     Canvas canvas,
     Measure measure, {
+    required int absoluteMeasureIndex,
     required double measureStartX,
     required double measureEndX,
     required double staffTop,
@@ -295,7 +297,7 @@ class ScoreNotationPainter extends CustomPainter {
           lineSpacing: staffLineSpacing,
         );
         final isSelected =
-            selectedMeasureIndex == row.globalStartMeasureIndex + measureInRow &&
+            selectedMeasureIndex == absoluteMeasureIndex &&
             selectedSymbolIndex == i;
         if (isSelected) {
           _drawSelectionHighlight(canvas, Offset(x, y));
@@ -304,7 +306,7 @@ class ScoreNotationPainter extends CustomPainter {
       } else if (symbol is Rest) {
         final y = _symbolCenterY(symbol, staffTop, staffBottom);
         final isSelected =
-            selectedMeasureIndex == row.globalStartMeasureIndex + measureInRow &&
+            selectedMeasureIndex == absoluteMeasureIndex &&
             selectedSymbolIndex == i;
         if (isSelected) {
           _drawSelectionHighlight(canvas, Offset(x, y));

--- a/lib/features/editor/domain/editor_actions.dart
+++ b/lib/features/editor/domain/editor_actions.dart
@@ -49,6 +49,10 @@ extension EditorActions on EditorState {
 
     final symbol = selectedSymbol;
     if (symbol is Note) {
+      final isSameDuration =
+          symbol.duration == durationSpec.divisions &&
+          symbol.type == durationSpec.type;
+      if (isSameDuration) return this;
       return _replaceSelectedSymbol(
         Note(
           step: symbol.step,
@@ -63,6 +67,10 @@ extension EditorActions on EditorState {
     }
 
     if (symbol is Rest) {
+      final isSameDuration =
+          symbol.duration == durationSpec.divisions &&
+          symbol.type == durationSpec.type;
+      if (isSameDuration) return this;
       return _replaceSelectedSymbol(
         Rest(
           duration: durationSpec.divisions,
@@ -77,44 +85,19 @@ extension EditorActions on EditorState {
   }
 
   EditorState insertNoteAfterSelection() {
-    final note = selectedSymbol is Note
-        ? selectedSymbol as Note
-        : const Note(step: 'C', octave: 4, duration: 1, type: 'quarter');
+    if (selectedPartIndex == null || selectedMeasureIndex == null) return this;
 
-    final newNote = Note(
-      step: note.step,
-      octave: note.octave,
-      alter: note.alter,
-      duration: note.duration,
-      type: note.type,
-      voice: note.voice,
-      staff: note.staff,
+    return _appendToSelectedMeasure(
+      const Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
     );
-
-    if (!hasSelection) {
-      return _insertWithoutSelection(newNote);
-    }
-
-    return _insertAfterSelection(newNote);
   }
 
   EditorState insertRestAfterSelection() {
-    final rest = selectedSymbol is Rest
-        ? selectedSymbol as Rest
-        : const Rest(duration: 1, type: 'quarter');
+    if (selectedPartIndex == null || selectedMeasureIndex == null) return this;
 
-    final newRest = Rest(
-      duration: rest.duration,
-      type: rest.type,
-      voice: rest.voice,
-      staff: rest.staff,
+    return _appendToSelectedMeasure(
+      const Rest(duration: 1, type: 'quarter'),
     );
-
-    if (!hasSelection) {
-      return _insertWithoutSelection(newRest);
-    }
-
-    return _insertAfterSelection(newRest);
   }
 
   EditorState deleteSelectedSymbol() {
@@ -174,43 +157,15 @@ extension EditorActions on EditorState {
     );
   }
 
-  EditorState _insertAfterSelection(ScoreSymbol symbol) {
+  EditorState _appendToSelectedMeasure(ScoreSymbol symbol) {
     final partIndex = selectedPartIndex!;
     final measureIndex = selectedMeasureIndex!;
-    final insertIndex = selectedSymbolIndex! + 1;
 
     final symbols = List<ScoreSymbol>.from(
       score.parts[partIndex].measures[measureIndex].symbols,
     );
+    final insertIndex = symbols.length;
     symbols.insert(insertIndex, symbol);
-
-    final nextScore = _replaceMeasureSymbols(
-      partIndex: partIndex,
-      measureIndex: measureIndex,
-      symbols: symbols,
-    );
-
-    return applyEdit(
-      score: nextScore,
-      selectedPartIndex: partIndex,
-      selectedMeasureIndex: measureIndex,
-      selectedSymbolIndex: insertIndex,
-      selectedSymbol: symbol,
-    );
-  }
-
-  EditorState _insertWithoutSelection(ScoreSymbol symbol) {
-    if (score.parts.isEmpty || score.parts.first.measures.isEmpty) {
-      return this;
-    }
-
-    const partIndex = 0;
-    const measureIndex = 0;
-    final symbols = List<ScoreSymbol>.from(
-      score.parts[partIndex].measures[measureIndex].symbols,
-    );
-    symbols.add(symbol);
-    final insertIndex = symbols.length - 1;
 
     final nextScore = _replaceMeasureSymbols(
       partIndex: partIndex,

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -74,6 +74,9 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
   Widget build(BuildContext context) {
     final selected = _editorState.selectedSymbol;
     final hasSelection = _editorState.hasSelection;
+    final hasMeasureContext =
+        _editorState.selectedPartIndex != null &&
+        _editorState.selectedMeasureIndex != null;
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -134,6 +137,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                 _EditorActionBar(
                   horizontalPadding: horizontalPadding,
                   hasSelection: hasSelection,
+                  hasMeasureContext: hasMeasureContext,
                   canUndo: _editorState.canUndo,
                   canRedo: _editorState.canRedo,
                   onMoveUp: () => _updateState((s) => s.moveSelectedSymbolUp()),
@@ -274,6 +278,7 @@ class _EditorActionBar extends StatelessWidget {
   const _EditorActionBar({
     required this.horizontalPadding,
     required this.hasSelection,
+    required this.hasMeasureContext,
     required this.canUndo,
     required this.canRedo,
     required this.onMoveUp,
@@ -291,6 +296,7 @@ class _EditorActionBar extends StatelessWidget {
 
   final double horizontalPadding;
   final bool hasSelection;
+  final bool hasMeasureContext;
   final bool canUndo;
   final bool canRedo;
   final VoidCallback onMoveUp;
@@ -336,11 +342,11 @@ class _EditorActionBar extends StatelessWidget {
             _ActionButton(label: 'E', onPressed: hasSelection ? onEighth : null),
             _ActionButton(
               label: 'Insert Note',
-              onPressed: onInsertNote,
+              onPressed: hasMeasureContext ? onInsertNote : null,
             ),
             _ActionButton(
               label: 'Insert Rest',
-              onPressed: onInsertRest,
+              onPressed: hasMeasureContext ? onInsertRest : null,
             ),
             _ActionButton(
               label: 'Delete',

--- a/test/features/editor/domain/editor_actions_test.dart
+++ b/test/features/editor/domain/editor_actions_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:note_vision/core/models/measure.dart';
+import 'package:note_vision/core/models/note.dart';
+import 'package:note_vision/core/models/part.dart';
+import 'package:note_vision/core/models/rest.dart';
+import 'package:note_vision/core/models/score.dart';
+import 'package:note_vision/core/models/score_symbol.dart';
+import 'package:note_vision/features/editor/domain/editor_actions.dart';
+import 'package:note_vision/features/editor/model/editor_state.dart';
+
+void main() {
+  group('EditorActions', () {
+    test('move up/down is diatonic with octave transitions and preserves alter', () {
+      final upState = _selectedState(
+        const Note(
+          step: 'B',
+          octave: 4,
+          alter: -1,
+          duration: 1,
+          type: 'quarter',
+        ),
+      );
+
+      final movedUp = upState.moveSelectedSymbolUp();
+      final movedUpNote = movedUp.selectedSymbol! as Note;
+      expect(movedUpNote.step, 'C');
+      expect(movedUpNote.octave, 5);
+      expect(movedUpNote.alter, -1);
+
+      final downState = _selectedState(
+        const Note(
+          step: 'C',
+          octave: 4,
+          alter: 1,
+          duration: 1,
+          type: 'quarter',
+        ),
+      );
+
+      final movedDown = downState.moveSelectedSymbolDown();
+      final movedDownNote = movedDown.selectedSymbol! as Note;
+      expect(movedDownNote.step, 'B');
+      expect(movedDownNote.octave, 3);
+      expect(movedDownNote.alter, 1);
+    });
+
+    test('move up/down no-ops when selected symbol is rest', () {
+      final state = _selectedState(const Rest(duration: 1, type: 'quarter'));
+
+      expect(identical(state.moveSelectedSymbolUp(), state), isTrue);
+      expect(identical(state.moveSelectedSymbolDown(), state), isTrue);
+    });
+
+    test('duration change to same value is a no-op and does not push undo', () {
+      final state = _selectedState(
+        const Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+      );
+
+      final next = state.setSelectedDuration(quarterDuration);
+
+      expect(identical(next, state), isTrue);
+      expect(next.undoStack, isEmpty);
+    });
+
+    test('insert note/rest append to end of selected measure and auto-select', () {
+      final score = Score(
+        id: 's1',
+        title: 't',
+        composer: 'c',
+        parts: const [
+          Part(
+            id: 'p1',
+            name: 'P1',
+            measures: [
+              Measure(
+                number: 1,
+                symbols: [
+                  Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+                  Rest(duration: 1, type: 'quarter'),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final state = EditorState(score: score).copyWith(
+        selectedPartIndex: 0,
+        selectedMeasureIndex: 0,
+        selectedSymbolIndex: 0,
+        selectedSymbol: score.parts[0].measures[0].symbols[0],
+      );
+
+      final withInsertedNote = state.insertNoteAfterSelection();
+      final noteSymbols = withInsertedNote.score.parts[0].measures[0].symbols;
+      expect(noteSymbols.last, isA<Note>());
+      expect((noteSymbols.last as Note).pitch, 'C4');
+      expect(withInsertedNote.selectedSymbolIndex, noteSymbols.length - 1);
+
+      final withInsertedRest = withInsertedNote.insertRestAfterSelection();
+      final restSymbols = withInsertedRest.score.parts[0].measures[0].symbols;
+      expect(restSymbols.last, isA<Rest>());
+      expect((restSymbols.last as Rest).type, 'quarter');
+      expect(withInsertedRest.selectedSymbolIndex, restSymbols.length - 1);
+    });
+
+    test('insert note/rest no-op with no measure context', () {
+      final score = _baseScore(const []);
+      final state = EditorState(score: score);
+
+      expect(identical(state.insertNoteAfterSelection(), state), isTrue);
+      expect(identical(state.insertRestAfterSelection(), state), isTrue);
+    });
+  });
+}
+
+EditorState _selectedState(ScoreSymbol symbol) {
+  final score = _baseScore([symbol]);
+  return EditorState(score: score).copyWith(
+    selectedPartIndex: 0,
+    selectedMeasureIndex: 0,
+    selectedSymbolIndex: 0,
+    selectedSymbol: score.parts[0].measures[0].symbols[0],
+  );
+}
+
+Score _baseScore(List<ScoreSymbol> symbols) => Score(
+  id: 'score-1',
+  title: 'Sample',
+  composer: 'Composer',
+  parts: [
+    Part(
+      id: 'part-1',
+      name: 'Piano',
+      measures: [
+        Measure(
+          number: 1,
+          symbols: symbols,
+        ),
+      ],
+    ),
+  ],
+);

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -64,7 +64,7 @@ void main() {
     expect(find.text('Redo'), findsOneWidget);
   });
 
-  testWidgets('allows insert actions with no selection and updates status', (
+  testWidgets('disables insert actions with no measure context', (
     tester,
   ) async {
     final score = buildScore(withSymbols: false);
@@ -88,17 +88,15 @@ void main() {
     final insertNoteButton = tester.widget<OutlinedButton>(
       find.widgetWithText(OutlinedButton, 'Insert Note'),
     );
-    expect(insertNoteButton.onPressed, isNotNull);
+    expect(insertNoteButton.onPressed, isNull);
 
     await tester.tap(find.widgetWithText(OutlinedButton, 'Move Up'));
     await tester.tap(find.widgetWithText(OutlinedButton, 'Insert Note'));
     await tester.pump();
 
     expect(tester.takeException(), isNull);
-    expect(find.text('Note'), findsOneWidget);
-    expect(find.text('C4'), findsOneWidget);
-    expect(find.text('quarter'), findsOneWidget);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('None'), findsOneWidget);
+    expect(find.text('—'), findsWidgets);
   });
 
   testWidgets('tapping symbols selects, reselects, and deselects', (tester) async {


### PR DESCRIPTION
### Motivation
- Prevent inserting notes/rests when there is no active measure context and make insertion behavior predictable by appending to the end of the selected measure.
- Avoid no-op edits being pushed to the undo stack when the duration is unchanged.
- Fix selection index computation used by the notation painter so symbol selection highlights compare against an absolute measure index.

### Description
- Added a `hasMeasureContext` flag to the UI and disabled the `Insert Note`/`Insert Rest` buttons when `selectedPartIndex` or `selectedMeasureIndex` is null, and propagated this flag into `_EditorActionBar`.
- Changed insertion logic: `insertNoteAfterSelection` and `insertRestAfterSelection` now return early when there is no measure context and otherwise call `_appendToSelectedMeasure` to append new symbols to the end of the currently selected measure instead of inserting after the selected symbol; removed the old `_insertWithoutSelection` code path.
- Short-circuited `setSelectedDuration` to return the same state when the selected symbol already has the requested `duration` and `type`, avoiding unnecessary edits.
- Fixed selection comparison in `ScoreNotationPainter` by passing an `absoluteMeasureIndex` into `_drawMeasureSymbols` and using it to determine whether a symbol is selected.
- Added unit tests for editor actions and updated widget tests to reflect the disabled insert behavior when there is no measure context.

### Testing
- Added `test/features/editor/domain/editor_actions_test.dart` covering diatonic move behavior, rest no-ops, duration no-op behavior, append-on-insert semantics, and no-op inserts with no measure context, and these tests passed.
- Updated `test/features/editor/presentation/editor_shell_screen_test.dart` to expect insert buttons disabled when no measure context, and widget tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7765705c08320b06b6a9dc0416032)