### PR TITLE
Restore empty-measure insertion and preserve measure context on delete

### DIFF
--- a/lib/features/editor/domain/editor_actions.dart
+++ b/lib/features/editor/domain/editor_actions.dart
@@ -118,13 +118,23 @@ extension EditorActions on EditorState {
       symbols: symbols,
     );
 
+    if (symbols.isEmpty) {
+      return applyEdit(
+        score: nextScore,
+        selectedPartIndex: partIndex,
+        selectedMeasureIndex: measureIndex,
+        selectedSymbolIndex: null,
+        selectedSymbol: null,
+      );
+    }
+
+    final nextIndex = symbolIndex.clamp(0, symbols.length - 1);
     return applyEdit(
       score: nextScore,
-      selectedPartIndex: null,
-      selectedMeasureIndex: null,
-      selectedSymbolIndex: null,
-      selectedSymbol: null,
-      clearSelection: true,
+      selectedPartIndex: partIndex,
+      selectedMeasureIndex: measureIndex,
+      selectedSymbolIndex: nextIndex,
+      selectedSymbol: symbols[nextIndex],
     );
   }
 

--- a/lib/features/editor/model/editor_state.dart
+++ b/lib/features/editor/model/editor_state.dart
@@ -92,18 +92,12 @@ class EditorState {
 
     if (allNull) return _Selection.none();
 
-    if (candidate.partIndex == null ||
-        candidate.measureIndex == null ||
-        candidate.symbolIndex == null ||
-        candidate.symbol == null) {
+    if (candidate.partIndex == null || candidate.measureIndex == null) {
       return _Selection.none();
     }
 
-    _validateSelectedSymbolType(candidate.symbol);
-
     final partIndex = candidate.partIndex!;
     final measureIndex = candidate.measureIndex!;
-    final symbolIndex = candidate.symbolIndex!;
 
     if (partIndex < 0 || partIndex >= score.parts.length) {
       return _Selection.none();
@@ -114,6 +108,24 @@ class EditorState {
       return _Selection.none();
     }
 
+    final hasSymbolSelection =
+        candidate.symbolIndex != null || candidate.symbol != null;
+    if (!hasSymbolSelection) {
+      return _Selection(
+        partIndex: partIndex,
+        measureIndex: measureIndex,
+        symbolIndex: null,
+        symbol: null,
+      );
+    }
+
+    if (candidate.symbolIndex == null || candidate.symbol == null) {
+      return _Selection.none();
+    }
+
+    _validateSelectedSymbolType(candidate.symbol);
+
+    final symbolIndex = candidate.symbolIndex!;
     final measure = part.measures[measureIndex];
     if (symbolIndex < 0 || symbolIndex >= measure.symbols.length) {
       return _Selection.none();

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -32,7 +32,9 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
   @override
   void initState() {
     super.initState();
-    _editorState = widget.args.initialState.copyWith(score: widget.args.score);
+    _editorState = _withDefaultMeasureContext(
+      widget.args.initialState.copyWith(score: widget.args.score),
+    );
   }
 
   void _updateState(EditorState Function(EditorState state) updater) {
@@ -49,7 +51,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
           state.selectedSymbolIndex == symbolIndex;
 
       if (isSameSelection) {
-        return state.copyWith(clearSelection: true);
+        return _clearSymbolSelection(state);
       }
 
       final parts = state.score.parts;
@@ -58,7 +60,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
       }
       final symbols = parts.first.measures[measureIndex].symbols;
       if (symbolIndex < 0 || symbolIndex >= symbols.length) {
-        return state.copyWith(clearSelection: true);
+        return _clearSymbolSelection(state);
       }
 
       return state.copyWith(
@@ -68,6 +70,27 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
         selectedSymbol: symbols[symbolIndex],
       );
     });
+  }
+
+  EditorState _withDefaultMeasureContext(EditorState state) {
+    if (state.selectedPartIndex != null && state.selectedMeasureIndex != null) {
+      return state;
+    }
+    if (state.score.parts.isEmpty || state.score.parts.first.measures.isEmpty) {
+      return state;
+    }
+    return state.copyWith(selectedPartIndex: 0, selectedMeasureIndex: 0);
+  }
+
+  EditorState _clearSymbolSelection(EditorState state) {
+    return EditorState(
+      score: state.score,
+      selectedPartIndex: state.selectedPartIndex,
+      selectedMeasureIndex: state.selectedMeasureIndex,
+      undoStack: state.undoStack,
+      redoStack: state.redoStack,
+      hasUnsavedChanges: state.hasUnsavedChanges,
+    );
   }
 
   @override
@@ -107,7 +130,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                           selectedSymbolIndex: _editorState.selectedSymbolIndex,
                           onSymbolTap: (target) {
                             if (target == null) {
-                              _updateState((state) => state.copyWith(clearSelection: true));
+                              _updateState((state) => _clearSymbolSelection(state));
                               return;
                             }
                             _onNotationSymbolTap(target.measureIndex, target.symbolIndex);

--- a/test/features/editor/domain/editor_actions_test.dart
+++ b/test/features/editor/domain/editor_actions_test.dart
@@ -111,6 +111,28 @@ void main() {
       expect(identical(state.insertNoteAfterSelection(), state), isTrue);
       expect(identical(state.insertRestAfterSelection(), state), isTrue);
     });
+
+    test('deleting last symbol keeps measure context so insert can recover', () {
+      final score = _baseScore(
+        const [Note(step: 'C', octave: 4, duration: 1, type: 'quarter')],
+      );
+      final selectedState = EditorState(score: score).copyWith(
+        selectedPartIndex: 0,
+        selectedMeasureIndex: 0,
+        selectedSymbolIndex: 0,
+        selectedSymbol: score.parts[0].measures[0].symbols[0],
+      );
+
+      final cleared = selectedState.deleteSelectedSymbol();
+      expect(cleared.selectedPartIndex, 0);
+      expect(cleared.selectedMeasureIndex, 0);
+      expect(cleared.selectedSymbolIndex, isNull);
+      expect(cleared.selectedSymbol, isNull);
+
+      final restored = cleared.insertNoteAfterSelection();
+      expect(restored.score.parts[0].measures[0].symbols, hasLength(1));
+      expect(restored.score.parts[0].measures[0].symbols.first, isA<Note>());
+    });
   });
 }
 

--- a/test/features/editor/model/editor_state_test.dart
+++ b/test/features/editor/model/editor_state_test.dart
@@ -76,6 +76,19 @@ void main() {
       expect(nextState.selectedSymbol, isNull);
     });
 
+    test('measure context can exist without selected symbol', () {
+      final score = _buildScore();
+      final state = EditorState(score: score).copyWith(
+        selectedPartIndex: 0,
+        selectedMeasureIndex: 0,
+      );
+
+      expect(state.selectedPartIndex, 0);
+      expect(state.selectedMeasureIndex, 0);
+      expect(state.selectedSymbolIndex, isNull);
+      expect(state.selectedSymbol, isNull);
+    });
+
     test('undo and redo stacks are capped at max depth 50', () {
       final entries = List.generate(
         55,

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -64,7 +64,7 @@ void main() {
     expect(find.text('Redo'), findsOneWidget);
   });
 
-  testWidgets('disables insert actions with no measure context', (
+  testWidgets('keeps insert actions enabled with default measure context', (
     tester,
   ) async {
     final score = buildScore(withSymbols: false);
@@ -88,15 +88,15 @@ void main() {
     final insertNoteButton = tester.widget<OutlinedButton>(
       find.widgetWithText(OutlinedButton, 'Insert Note'),
     );
-    expect(insertNoteButton.onPressed, isNull);
+    expect(insertNoteButton.onPressed, isNotNull);
 
     await tester.tap(find.widgetWithText(OutlinedButton, 'Move Up'));
     await tester.tap(find.widgetWithText(OutlinedButton, 'Insert Note'));
     await tester.pump();
 
     expect(tester.takeException(), isNull);
-    expect(find.text('None'), findsOneWidget);
-    expect(find.text('—'), findsWidgets);
+    expect(find.text('Note'), findsOneWidget);
+    expect(find.text('C4'), findsOneWidget);
   });
 
   testWidgets('tapping symbols selects, reselects, and deselects', (tester) async {


### PR DESCRIPTION
### Motivation
- Fix a high-priority regression where inserts into an empty measure became impossible after requiring a symbol selection context.  
- Allow a `part+measure` context to exist without a selected symbol so UI insert controls remain actionable for blank measures.  
- Ensure deleting the last symbol in a measure does not drop measure context so users can immediately re-insert into that measure.

### Description
- Relaxed selection normalization in `EditorState._normalizeSelection` to permit measure-only context (keep `selectedPartIndex`/`selectedMeasureIndex` set while allowing `selectedSymbolIndex`/`selectedSymbol` to be null).  
- Updated `deleteSelectedSymbol()` in `lib/features/editor/domain/editor_actions.dart` to preserve the part/measure context when the last symbol is removed and to set `selectedSymbolIndex`/`selectedSymbol` to `null` instead of clearing the entire selection.  
- Seeded a default measure context in `EditorShellScreen.initState` with `_withDefaultMeasureContext` so an empty score (or empty measure) has an active measure context when available, and added `_clearSymbolSelection` to clear only the symbol selection without dropping the measure context.  
- Adjusted/added tests to cover the fix: updated `test/features/editor/presentation/editor_shell_screen_test.dart`, added a recovery flow test in `test/features/editor/domain/editor_actions_test.dart`, and added a measure-only selection test in `test/features/editor/model/editor_state_test.dart`.

### Testing
- Added/updated unit and widget tests: `test/features/editor/domain/editor_actions_test.dart`, `test/features/editor/model/editor_state_test.dart`, and `test/features/editor/presentation/editor_shell_screen_test.dart`.  
- I attempted to run the Flutter test suite here but `flutter` is not available in this environment, so tests were not executed (`flutter: command not found`).  
- The changes were committed and a follow-up PR was prepared summarizing these fixes on top of the original changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c77e9323ec8320af0467605c605149)