### PR TITLE
Make EditorState.copyWith distinguish explicit nulls to clear selection

### DIFF
--- a/lib/features/editor/model/editor_state.dart
+++ b/lib/features/editor/model/editor_state.dart
@@ -8,6 +8,7 @@ import 'package:note_vision/features/editor/model/editor_snapshot.dart';
 
 class EditorState {
   static const int maxHistoryDepth = 50;
+  static const Object _unset = Object();
 
   final Score score;
   final int? selectedPartIndex;
@@ -34,10 +35,10 @@ class EditorState {
 
   EditorState copyWith({
     Score? score,
-    int? selectedPartIndex,
-    int? selectedMeasureIndex,
-    int? selectedSymbolIndex,
-    ScoreSymbol? selectedSymbol,
+    Object? selectedPartIndex = _unset,
+    Object? selectedMeasureIndex = _unset,
+    Object? selectedSymbolIndex = _unset,
+    Object? selectedSymbol = _unset,
     bool clearSelection = false,
     List<EditorSnapshot>? undoStack,
     List<EditorSnapshot>? redoStack,
@@ -48,10 +49,18 @@ class EditorState {
     final candidateSelection = clearSelection
         ? _Selection.none()
         : _Selection(
-            partIndex: selectedPartIndex ?? this.selectedPartIndex,
-            measureIndex: selectedMeasureIndex ?? this.selectedMeasureIndex,
-            symbolIndex: selectedSymbolIndex ?? this.selectedSymbolIndex,
-            symbol: selectedSymbol ?? this.selectedSymbol,
+            partIndex: selectedPartIndex == _unset
+                ? this.selectedPartIndex
+                : selectedPartIndex as int?,
+            measureIndex: selectedMeasureIndex == _unset
+                ? this.selectedMeasureIndex
+                : selectedMeasureIndex as int?,
+            symbolIndex: selectedSymbolIndex == _unset
+                ? this.selectedSymbolIndex
+                : selectedSymbolIndex as int?,
+            symbol: selectedSymbol == _unset
+                ? this.selectedSymbol
+                : selectedSymbol as ScoreSymbol?,
           );
 
     final normalizedSelection = _normalizeSelection(

--- a/test/features/editor/model/editor_state_test.dart
+++ b/test/features/editor/model/editor_state_test.dart
@@ -89,6 +89,26 @@ void main() {
       expect(state.selectedSymbol, isNull);
     });
 
+    test('copyWith can clear symbol selection while preserving measure context', () {
+      final score = _buildScore();
+      final selected = EditorState(score: score).copyWith(
+        selectedPartIndex: 0,
+        selectedMeasureIndex: 0,
+        selectedSymbolIndex: 0,
+        selectedSymbol: score.parts[0].measures[0].symbols[0],
+      );
+
+      final cleared = selected.copyWith(
+        selectedSymbolIndex: null,
+        selectedSymbol: null,
+      );
+
+      expect(cleared.selectedPartIndex, 0);
+      expect(cleared.selectedMeasureIndex, 0);
+      expect(cleared.selectedSymbolIndex, isNull);
+      expect(cleared.selectedSymbol, isNull);
+    });
+
     test('undo and redo stacks are capped at max depth 50', () {
       final entries = List.generate(
         55,


### PR DESCRIPTION
### Motivation

- Allow callers of `EditorState.copyWith` to explicitly clear selection fields by passing `null` while still being able to omit parameters to keep existing values.

### Description

- Introduced a sentinel `static const Object _unset = Object();` and changed `copyWith` parameters to accept `Object?` defaults of `_unset` so omitted args are distinguishable from explicit `null`.
- Updated selection construction to check for `_unset` and either retain current selection or use the provided `null`/value, with appropriate casts to `int?` and `ScoreSymbol?`.
- Kept stack trimming behavior intact and continued to wrap `undoStack`/`redoStack` with `UnmodifiableListView`.
- Added a unit test `copyWith can clear symbol selection while preserving measure context` to verify clearing symbol selection while preserving measure context works as intended.

### Testing

- Ran the editor model unit tests including `test/features/editor/model/editor_state_test.dart` (new test added) via the project's test runner; all tests passed.
- The new test verifying explicit `null` clearing of `selectedSymbol` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c781c5e6b88320a06f8a19f79058fc)