### PR TITLE
Add long-press in-measure drag reorder with undo support

### DIFF
--- a/lib/core/widgets/score_notation/score_notation_painter.dart
+++ b/lib/core/widgets/score_notation/score_notation_painter.dart
@@ -20,6 +20,7 @@ class ScoreNotationPainter extends CustomPainter {
     required this.rowPrefixWidth,
     this.selectedMeasureIndex,
     this.selectedSymbolIndex,
+    this.dragFeedback,
   });
 
   final List<Measure> measures;
@@ -30,6 +31,7 @@ class ScoreNotationPainter extends CustomPainter {
   final double rowPrefixWidth;
   final int? selectedMeasureIndex;
   final int? selectedSymbolIndex;
+  final NotationDragFeedback? dragFeedback;
 
   static const double staffLineSpacing = 12;
   static const double tapTargetSize = 24;
@@ -283,10 +285,34 @@ class ScoreNotationPainter extends CustomPainter {
       (measureEndX - measureStartX) - (innerPadding * 2),
     );
     final middleLineY = staffTop + staffLineSpacing * 2;
+    final drag = dragFeedback;
+    final hasDragInMeasure =
+        drag != null &&
+        drag.measureIndex == absoluteMeasureIndex &&
+        drag.draggedSymbolIndex >= 0 &&
+        drag.draggedSymbolIndex < symbolCount &&
+        drag.targetSymbolIndex >= 0 &&
+        drag.targetSymbolIndex < symbolCount;
+    final draggedSymbol = hasDragInMeasure ? measure.symbols[drag!.draggedSymbolIndex] : null;
+    final clampedDragX = hasDragInMeasure
+        ? drag!.dragX.clamp(
+            measureStartX + innerPadding,
+            measureEndX - innerPadding,
+          )
+        : 0.0;
 
     for (var i = 0; i < symbolCount; i++) {
+      if (hasDragInMeasure && i == drag!.draggedSymbolIndex) {
+        continue;
+      }
       final symbol = measure.symbols[i];
-      final progress = (i + 1) / (symbolCount + 1);
+      var visualIndex = i;
+      if (hasDragInMeasure) {
+        final compactIndex = i > drag!.draggedSymbolIndex ? i - 1 : i;
+        visualIndex =
+            compactIndex >= drag.targetSymbolIndex ? compactIndex + 1 : compactIndex;
+      }
+      final progress = (visualIndex + 1) / (symbolCount + 1);
       final x = measureStartX + innerPadding + (drawableWidth * progress);
 
       if (symbol is Note) {
@@ -314,13 +340,30 @@ class ScoreNotationPainter extends CustomPainter {
         _drawRest(canvas, symbol, x: x, staffTop: staffTop);
       }
     }
+
+    if (!hasDragInMeasure || draggedSymbol == null) return;
+
+    final dragY = _symbolCenterY(draggedSymbol, staffTop, staffBottom) - 8;
+    if (draggedSymbol is Note) {
+      _drawSelectionHighlight(canvas, Offset(clampedDragX, dragY), radius: 16);
+      _drawNote(
+        canvas,
+        draggedSymbol,
+        x: clampedDragX,
+        y: dragY,
+        middleLineY: middleLineY,
+      );
+    } else if (draggedSymbol is Rest) {
+      _drawSelectionHighlight(canvas, Offset(clampedDragX, dragY), radius: 16);
+      _drawRest(canvas, draggedSymbol, x: clampedDragX, staffTop: staffTop - 8);
+    }
   }
 
-  void _drawSelectionHighlight(Canvas canvas, Offset center) {
+  void _drawSelectionHighlight(Canvas canvas, Offset center, {double radius = 14}) {
     final paint = Paint()
       ..color = const Color(0xFFD4A96A).withValues(alpha: 0.26)
       ..style = PaintingStyle.fill;
-    canvas.drawCircle(center, 14, paint);
+    canvas.drawCircle(center, radius, paint);
   }
 
   void _drawNote(
@@ -605,7 +648,8 @@ class ScoreNotationPainter extends CustomPainter {
         oldDelegate.padding != padding ||
         oldDelegate.rowPrefixWidth != rowPrefixWidth ||
         oldDelegate.selectedMeasureIndex != selectedMeasureIndex ||
-        oldDelegate.selectedSymbolIndex != selectedSymbolIndex;
+        oldDelegate.selectedSymbolIndex != selectedSymbolIndex ||
+        oldDelegate.dragFeedback != dragFeedback;
   }
 }
 
@@ -621,6 +665,37 @@ class NotationSymbolTarget {
   final int symbolIndex;
   final Offset center;
   final Rect hitRect;
+}
+
+class NotationDragFeedback {
+  const NotationDragFeedback({
+    required this.measureIndex,
+    required this.draggedSymbolIndex,
+    required this.targetSymbolIndex,
+    required this.dragX,
+  });
+
+  final int measureIndex;
+  final int draggedSymbolIndex;
+  final int targetSymbolIndex;
+  final double dragX;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NotationDragFeedback &&
+          runtimeType == other.runtimeType &&
+          measureIndex == other.measureIndex &&
+          draggedSymbolIndex == other.draggedSymbolIndex &&
+          targetSymbolIndex == other.targetSymbolIndex &&
+          dragX == other.dragX;
+
+  @override
+  int get hashCode =>
+      measureIndex.hashCode ^
+      draggedSymbolIndex.hashCode ^
+      targetSymbolIndex.hashCode ^
+      dragX.hashCode;
 }
 
 class _RowMetrics {

--- a/lib/core/widgets/score_notation_viewer.dart
+++ b/lib/core/widgets/score_notation_viewer.dart
@@ -22,6 +22,7 @@ class ScoreNotationViewer extends StatefulWidget {
     this.selectedMeasureIndex,
     this.selectedSymbolIndex,
     this.onSymbolTap,
+    this.onSymbolReorder,
   });
 
   final Score? score;
@@ -33,6 +34,7 @@ class ScoreNotationViewer extends StatefulWidget {
   final int? selectedMeasureIndex;
   final int? selectedSymbolIndex;
   final ValueChanged<NotationSymbolTarget?>? onSymbolTap;
+  final ValueChanged<NotationSymbolReorder>? onSymbolReorder;
 
   @override
   State<ScoreNotationViewer> createState() => _ScoreNotationViewerState();
@@ -42,6 +44,7 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
   final ScrollController _horizontalController = ScrollController();
   final NotationLayoutCalculator _layoutCalculator =
       const NotationLayoutCalculator();
+  _NotationDragSession? _dragSession;
 
   @override
   void dispose() {
@@ -87,6 +90,16 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
               final tapped = _nearestTarget(adjusted, targets);
               widget.onSymbolTap?.call(tapped);
             },
+      onLongPressStart: widget.onSymbolReorder == null
+          ? null
+          : (position) => _beginDrag(measures: measures, layout: layout, position: position),
+      onLongPressMoveUpdate: widget.onSymbolReorder == null
+          ? null
+          : (position) => _updateDrag(measures: measures, layout: layout, position: position),
+      onLongPressEnd: widget.onSymbolReorder == null
+          ? null
+          : (position) => _endDrag(measures: measures, layout: layout, position: position),
+      onLongPressCancel: widget.onSymbolReorder == null ? null : _cancelDrag,
       painter: ScoreNotationPainter(
         measures: measures,
         measuresPerRow: layout.measuresPerRow,
@@ -96,7 +109,141 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
         rowPrefixWidth: layout.rowPrefixWidth,
         selectedMeasureIndex: widget.selectedMeasureIndex,
         selectedSymbolIndex: widget.selectedSymbolIndex,
+        dragFeedback: _dragSession == null
+            ? null
+            : NotationDragFeedback(
+                measureIndex: _dragSession!.measureIndex,
+                draggedSymbolIndex: _dragSession!.fromSymbolIndex,
+                targetSymbolIndex: _dragSession!.toSymbolIndex,
+                dragX: _dragSession!.dragPosition.dx,
+              ),
       ),
+    );
+  }
+
+  void _beginDrag({
+    required List<Measure> measures,
+    required NotationLayout layout,
+    required Offset position,
+  }) {
+    final adjusted = _adjustForHorizontalScroll(position);
+    final targets = ScoreNotationPainter.buildSymbolTargets(
+      measures: measures,
+      measuresPerRow: layout.measuresPerRow,
+      minMeasureWidth: widget.minMeasureWidth,
+      rowHeight: widget.rowHeight,
+      padding: widget.padding,
+      rowPrefixWidth: layout.rowPrefixWidth,
+    );
+    final pressed = _nearestTarget(adjusted, targets);
+    if (pressed == null) return;
+
+    setState(() {
+      _dragSession = _NotationDragSession(
+        measureIndex: pressed.measureIndex,
+        fromSymbolIndex: pressed.symbolIndex,
+        toSymbolIndex: pressed.symbolIndex,
+        dragPosition: adjusted,
+      );
+    });
+  }
+
+  void _updateDrag({
+    required List<Measure> measures,
+    required NotationLayout layout,
+    required Offset position,
+  }) {
+    final drag = _dragSession;
+    if (drag == null) return;
+    final adjusted = _adjustForHorizontalScroll(position);
+    final toIndex = _targetIndexForDrag(
+      measures: measures,
+      layout: layout,
+      measureIndex: drag.measureIndex,
+      fromSymbolIndex: drag.fromSymbolIndex,
+      dragPosition: adjusted,
+    );
+    if (toIndex == null) return;
+
+    setState(() {
+      _dragSession = drag.copyWith(toSymbolIndex: toIndex, dragPosition: adjusted);
+    });
+  }
+
+  void _endDrag({
+    required List<Measure> measures,
+    required NotationLayout layout,
+    required Offset position,
+  }) {
+    final drag = _dragSession;
+    if (drag == null) return;
+    final adjusted = _adjustForHorizontalScroll(position);
+    final toIndex = _targetIndexForDrag(
+      measures: measures,
+      layout: layout,
+      measureIndex: drag.measureIndex,
+      fromSymbolIndex: drag.fromSymbolIndex,
+      dragPosition: adjusted,
+    );
+    final resolvedIndex = toIndex ?? drag.toSymbolIndex;
+
+    if (resolvedIndex != drag.fromSymbolIndex) {
+      widget.onSymbolReorder?.call(
+        NotationSymbolReorder(
+          measureIndex: drag.measureIndex,
+          fromSymbolIndex: drag.fromSymbolIndex,
+          toSymbolIndex: resolvedIndex,
+        ),
+      );
+    }
+
+    setState(() {
+      _dragSession = null;
+    });
+  }
+
+  void _cancelDrag() {
+    if (_dragSession == null) return;
+    setState(() {
+      _dragSession = null;
+    });
+  }
+
+  int? _targetIndexForDrag({
+    required List<Measure> measures,
+    required NotationLayout layout,
+    required int measureIndex,
+    required int fromSymbolIndex,
+    required Offset dragPosition,
+  }) {
+    if (measureIndex < 0 || measureIndex >= measures.length) return null;
+    final symbolCount = measures[measureIndex].symbols.length;
+    if (symbolCount <= 1 || fromSymbolIndex < 0 || fromSymbolIndex >= symbolCount) {
+      return null;
+    }
+
+    final targets = ScoreNotationPainter.buildSymbolTargets(
+      measures: measures,
+      measuresPerRow: layout.measuresPerRow,
+      minMeasureWidth: widget.minMeasureWidth,
+      rowHeight: widget.rowHeight,
+      padding: widget.padding,
+      rowPrefixWidth: layout.rowPrefixWidth,
+    ).where((target) => target.measureIndex == measureIndex && target.symbolIndex != fromSymbolIndex);
+
+    var insertIndex = 0;
+    for (final target in targets) {
+      if (dragPosition.dx > target.center.dx) {
+        insertIndex++;
+      }
+    }
+    return insertIndex.clamp(0, symbolCount - 1);
+  }
+
+  Offset _adjustForHorizontalScroll(Offset position) {
+    return position.translate(
+      _horizontalController.hasClients ? _horizontalController.offset : 0,
+      0,
     );
   }
 
@@ -130,6 +277,10 @@ class _NotationCanvasFrame extends StatelessWidget {
     required this.size,
     required this.painter,
     this.onTapUp,
+    this.onLongPressStart,
+    this.onLongPressMoveUpdate,
+    this.onLongPressEnd,
+    this.onLongPressCancel,
   });
 
   final Color backgroundColor;
@@ -137,6 +288,10 @@ class _NotationCanvasFrame extends StatelessWidget {
   final Size size;
   final CustomPainter painter;
   final ValueChanged<Offset>? onTapUp;
+  final ValueChanged<Offset>? onLongPressStart;
+  final ValueChanged<Offset>? onLongPressMoveUpdate;
+  final ValueChanged<Offset>? onLongPressEnd;
+  final VoidCallback? onLongPressCancel;
 
   @override
   Widget build(BuildContext context) {
@@ -149,12 +304,59 @@ class _NotationCanvasFrame extends StatelessWidget {
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTapUp: onTapUp == null ? null : (details) => onTapUp!(details.localPosition),
+        onLongPressStart: onLongPressStart == null
+            ? null
+            : (details) => onLongPressStart!(details.localPosition),
+        onLongPressMoveUpdate: onLongPressMoveUpdate == null
+            ? null
+            : (details) => onLongPressMoveUpdate!(details.localPosition),
+        onLongPressEnd:
+            onLongPressEnd == null ? null : (details) => onLongPressEnd!(details.localPosition),
+        onLongPressCancel: onLongPressCancel,
         child: SingleChildScrollView(
           controller: horizontalController,
           scrollDirection: Axis.horizontal,
           child: CustomPaint(size: size, painter: painter),
         ),
       ),
+    );
+  }
+}
+
+class NotationSymbolReorder {
+  const NotationSymbolReorder({
+    required this.measureIndex,
+    required this.fromSymbolIndex,
+    required this.toSymbolIndex,
+  });
+
+  final int measureIndex;
+  final int fromSymbolIndex;
+  final int toSymbolIndex;
+}
+
+class _NotationDragSession {
+  const _NotationDragSession({
+    required this.measureIndex,
+    required this.fromSymbolIndex,
+    required this.toSymbolIndex,
+    required this.dragPosition,
+  });
+
+  final int measureIndex;
+  final int fromSymbolIndex;
+  final int toSymbolIndex;
+  final Offset dragPosition;
+
+  _NotationDragSession copyWith({
+    int? toSymbolIndex,
+    Offset? dragPosition,
+  }) {
+    return _NotationDragSession(
+      measureIndex: measureIndex,
+      fromSymbolIndex: fromSymbolIndex,
+      toSymbolIndex: toSymbolIndex ?? this.toSymbolIndex,
+      dragPosition: dragPosition ?? this.dragPosition,
     );
   }
 }

--- a/lib/features/editor/domain/editor_actions.dart
+++ b/lib/features/editor/domain/editor_actions.dart
@@ -142,6 +142,68 @@ extension EditorActions on EditorState {
 
   EditorState applyRedo() => redo();
 
+  EditorState reorderSymbolWithinMeasure({
+    required int measureIndex,
+    required int fromSymbolIndex,
+    required int toSymbolIndex,
+  }) {
+    if (score.parts.isEmpty) return this;
+    final partIndex = 0;
+    final measures = score.parts[partIndex].measures;
+    if (measureIndex < 0 || measureIndex >= measures.length) return this;
+
+    final currentSymbols = measures[measureIndex].symbols;
+    if (fromSymbolIndex < 0 || fromSymbolIndex >= currentSymbols.length) return this;
+    if (toSymbolIndex < 0 || toSymbolIndex >= currentSymbols.length) return this;
+    if (fromSymbolIndex == toSymbolIndex) return this;
+
+    final symbols = List<ScoreSymbol>.from(currentSymbols);
+    final movedSymbol = symbols.removeAt(fromSymbolIndex);
+    symbols.insert(toSymbolIndex, movedSymbol);
+
+    final nextScore = _replaceMeasureSymbols(
+      partIndex: partIndex,
+      measureIndex: measureIndex,
+      symbols: symbols,
+    );
+
+    final selectedPart = selectedPartIndex;
+    final selectedMeasure = selectedMeasureIndex;
+    final selectedIndex = selectedSymbolIndex;
+    final selected = selectedSymbol;
+
+    if (selectedPart != partIndex ||
+        selectedMeasure != measureIndex ||
+        selectedIndex == null ||
+        selected == null) {
+      return applyEdit(
+        score: nextScore,
+        selectedPartIndex: selectedPartIndex,
+        selectedMeasureIndex: selectedMeasureIndex,
+        selectedSymbolIndex: selectedSymbolIndex,
+        selectedSymbol: selectedSymbol,
+      );
+    }
+
+    int nextSelectedIndex = selectedIndex;
+
+    if (selectedIndex == fromSymbolIndex) {
+      nextSelectedIndex = toSymbolIndex;
+    } else if (fromSymbolIndex < selectedIndex && toSymbolIndex >= selectedIndex) {
+      nextSelectedIndex = selectedIndex - 1;
+    } else if (fromSymbolIndex > selectedIndex && toSymbolIndex <= selectedIndex) {
+      nextSelectedIndex = selectedIndex + 1;
+    }
+
+    return applyEdit(
+      score: nextScore,
+      selectedPartIndex: partIndex,
+      selectedMeasureIndex: measureIndex,
+      selectedSymbolIndex: nextSelectedIndex,
+      selectedSymbol: symbols[nextSelectedIndex],
+    );
+  }
+
   EditorState _replaceSelectedSymbol(ScoreSymbol symbol) {
     final partIndex = selectedPartIndex!;
     final measureIndex = selectedMeasureIndex!;

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -135,6 +135,15 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                             }
                             _onNotationSymbolTap(target.measureIndex, target.symbolIndex);
                           },
+                          onSymbolReorder: (event) {
+                            _updateState(
+                              (state) => state.reorderSymbolWithinMeasure(
+                                measureIndex: event.measureIndex,
+                                fromSymbolIndex: event.fromSymbolIndex,
+                                toSymbolIndex: event.toSymbolIndex,
+                              ),
+                            );
+                          },
                         ),
                       ),
                     ),

--- a/test/core/widgets/score_notation_viewer_test.dart
+++ b/test/core/widgets/score_notation_viewer_test.dart
@@ -170,5 +170,113 @@ void main() {
 
       expect(taps, equals([(0, 0), (0, 1)]));
     });
+
+    testWidgets('long-press drag reorders symbols within the same measure', (
+      tester,
+    ) async {
+      final score = Score(
+        id: 'drag-reorder',
+        title: 'Drag reorder',
+        composer: 'Tester',
+        parts: [
+          Part(
+            id: 'P1',
+            name: 'Part 1',
+            measures: [
+              Measure(
+                number: 1,
+                symbols: const [
+                  Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+                  Rest(duration: 1, type: 'quarter'),
+                  Note(step: 'E', octave: 4, duration: 1, type: 'quarter'),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+
+      NotationSymbolReorder? reorderEvent;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ScoreNotationViewer(
+              score: score,
+              onSymbolReorder: (event) {
+                reorderEvent = event;
+              },
+            ),
+          ),
+        ),
+      );
+
+      final origin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+      final gesture = await tester.startGesture(origin + const Offset(146, 68));
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 20));
+      await gesture.moveTo(origin + const Offset(198, 68));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(reorderEvent, isNotNull);
+      expect(reorderEvent!.measureIndex, 0);
+      expect(reorderEvent!.fromSymbolIndex, 0);
+      expect(reorderEvent!.toSymbolIndex, 2);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('drag cannot move symbol across measure boundary', (tester) async {
+      final score = Score(
+        id: 'drag-boundary',
+        title: 'Drag boundary',
+        composer: 'Tester',
+        parts: [
+          Part(
+            id: 'P1',
+            name: 'Part 1',
+            measures: [
+              Measure(
+                number: 1,
+                symbols: const [
+                  Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+                ],
+              ),
+              Measure(
+                number: 2,
+                symbols: const [
+                  Rest(duration: 1, type: 'quarter'),
+                  Note(step: 'E', octave: 4, duration: 1, type: 'quarter'),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+
+      NotationSymbolReorder? reorderEvent;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ScoreNotationViewer(
+              score: score,
+              onSymbolReorder: (event) {
+                reorderEvent = event;
+              },
+            ),
+          ),
+        ),
+      );
+
+      final origin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+      final gesture = await tester.startGesture(origin + const Offset(184, 68));
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 20));
+      await gesture.moveTo(origin + const Offset(315, 68));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(reorderEvent, isNull);
+      expect(tester.takeException(), isNull);
+    });
   });
 }

--- a/test/features/editor/domain/editor_actions_test.dart
+++ b/test/features/editor/domain/editor_actions_test.dart
@@ -133,6 +133,85 @@ void main() {
       expect(restored.score.parts[0].measures[0].symbols, hasLength(1));
       expect(restored.score.parts[0].measures[0].symbols.first, isA<Note>());
     });
+
+    test('reorderSymbolWithinMeasure reorders and preserves selection', () {
+      final score = Score(
+        id: 's-reorder',
+        title: 't',
+        composer: 'c',
+        parts: const [
+          Part(
+            id: 'p1',
+            name: 'P1',
+            measures: [
+              Measure(
+                number: 1,
+                symbols: [
+                  Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+                  Rest(duration: 1, type: 'quarter'),
+                  Note(step: 'E', octave: 4, duration: 1, type: 'quarter'),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final selected = EditorState(score: score).copyWith(
+        selectedPartIndex: 0,
+        selectedMeasureIndex: 0,
+        selectedSymbolIndex: 0,
+        selectedSymbol: score.parts[0].measures[0].symbols[0],
+      );
+
+      final moved = selected.reorderSymbolWithinMeasure(
+        measureIndex: 0,
+        fromSymbolIndex: 0,
+        toSymbolIndex: 2,
+      );
+      final symbols = moved.score.parts[0].measures[0].symbols;
+      expect(symbols[0], isA<Rest>());
+      expect((symbols[1] as Note).pitch, 'E4');
+      expect((symbols[2] as Note).pitch, 'C4');
+      expect(moved.selectedSymbolIndex, 2);
+      expect((moved.selectedSymbol! as Note).pitch, 'C4');
+      expect(moved.undoStack, isNotEmpty);
+    });
+
+    test('reorderSymbolWithinMeasure cannot move symbol across measure boundary', () {
+      final score = Score(
+        id: 's-multi',
+        title: 't',
+        composer: 'c',
+        parts: const [
+          Part(
+            id: 'p1',
+            name: 'P1',
+            measures: [
+              Measure(
+                number: 1,
+                symbols: [Note(step: 'C', octave: 4, duration: 1, type: 'quarter')],
+              ),
+              Measure(
+                number: 2,
+                symbols: [Rest(duration: 1, type: 'quarter')],
+              ),
+            ],
+          ),
+        ],
+      );
+      final state = EditorState(score: score);
+
+      final unchanged = state.reorderSymbolWithinMeasure(
+        measureIndex: 0,
+        fromSymbolIndex: 0,
+        toSymbolIndex: 1,
+      );
+
+      expect(identical(unchanged, state), isTrue);
+      expect(unchanged.undoStack, isEmpty);
+      expect(unchanged.score.parts[0].measures[1].symbols.single, isA<Rest>());
+    });
   });
 }
 

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -134,4 +134,60 @@ void main() {
     expect(find.text('None'), findsOneWidget);
     expect(tester.widget<OutlinedButton>(moveUpButtonFinder).onPressed, isNull);
   });
+
+  testWidgets('drag reorder updates model order and undo restores original order', (
+    tester,
+  ) async {
+    final score = Score(
+      id: 'score-reorder',
+      title: 'Test Score',
+      composer: 'Composer',
+      parts: [
+        Part(
+          id: 'P1',
+          name: 'Part 1',
+          measures: [
+            Measure(
+              number: 1,
+              symbols: const [
+                Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+                Note(step: 'E', octave: 4, duration: 1, type: 'quarter'),
+                Rest(duration: 1, type: 'quarter'),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+
+    final origin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    final dragGesture = await tester.startGesture(origin + const Offset(146, 68));
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 20));
+    await dragGesture.moveTo(origin + const Offset(198, 68));
+    await tester.pump();
+    await dragGesture.up();
+    await tester.pump();
+
+    await tester.tapAt(origin + const Offset(146, 68));
+    await tester.pump();
+    expect(find.text('E4'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Undo'));
+    await tester.pump();
+
+    await tester.tapAt(origin + const Offset(146, 68));
+    await tester.pump();
+    expect(find.text('C4'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
### Motivation
- Provide a way for users to reorder existing symbols inside a measure by long-press dragging a symbol, showing runtime feedback and committing the change to the score model on drop so undo/redo works as expected.
- Constrain Sprint 5 behavior to in-measure reordering only and ensure no crashes occur for valid scores during drag.

### Description
- Implemented `reorderSymbolWithinMeasure` in `EditorActions` which validates bounds, produces a new `Score` via `_replaceMeasureSymbols`, preserves/updates selection, and pushes the previous state onto the undo stack through the existing `applyEdit` flow.
- Extended `ScoreNotationViewer` with long-press gesture handlers (`onLongPressStart`, `onLongPressMoveUpdate`, `onLongPressEnd`, `onLongPressCancel`), a `_NotationDragSession` to track drag state, and emits `NotationSymbolReorder` events to the caller when a drop results in a reorder.
- Added drag rendering to the notation painter by introducing `NotationDragFeedback` which makes the dragged symbol appear lifted and reserves a visual gap at the target position; updated `shouldRepaint` to include drag feedback.
- Wired reorder events into the editor UI in `EditorShellScreen` so drops call `reorderSymbolWithinMeasure`, causing the `ScoreModel` to update and the viewer to re-render with the new order.
- Added tests to exercise the new behavior: viewer drag handling and boundary restriction (`test/core/widgets/score_notation_viewer_test.dart`), editor-domain reorder logic and undo push (`test/features/editor/domain/editor_actions_test.dart`), and an end-to-end editor-shell drag+undo flow (`test/features/editor/presentation/editor_shell_screen_test.dart`).

### Testing
- Added unit and widget tests covering reorder semantics, selection preservation, undo stack push, viewer drag callbacks, measure-boundary restriction, and no-crash expectations (`test/core/widgets/score_notation_viewer_test.dart`, `test/features/editor/domain/editor_actions_test.dart`, `test/features/editor/presentation/editor_shell_screen_test.dart`).
- Attempted to run the test suite with `flutter test test/features/editor/domain/editor_actions_test.dart test/core/widgets/score_notation_viewer_test.dart test/features/editor/presentation/editor_shell_screen_test.dart` but the environment could not run them because `flutter` was not installed (`/bin/bash: flutter: command not found`).
- All added tests are present and ready to run in a Flutter-enabled CI or developer environment and validate the acceptance criteria (in-measure reorder, model update, viewer re-render, undo behavior, and boundary protection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c78c6cab988320b92538d3f07347cb)