### PR TITLE
Fix scan flow safeguards and unify inspector theming

### DIFF
--- a/lib/core/widgets/inspector_shared_widgets.dart
+++ b/lib/core/widgets/inspector_shared_widgets.dart
@@ -13,8 +13,9 @@ class SectionCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: const Color(0xFFF7F7F7),
+        color: const Color(0xFF1A1A1A),
         borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: const Color(0xFF2C2C2C), width: 0.5),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -24,7 +25,7 @@ class SectionCard extends StatelessWidget {
             style: const TextStyle(
               fontSize: 10,
               fontWeight: FontWeight.w600,
-              color: Color(0xFF999999),
+              color: Color(0xFF8A8A8A),
               letterSpacing: 0.8,
             ),
           ),
@@ -51,7 +52,7 @@ class InspectorBadge extends StatelessWidget {
     final (bg, fg) = switch (style) {
       BadgeStyle.success => (const Color(0xFFDCFCE7), const Color(0xFF15803D)),
       BadgeStyle.fail    => (const Color(0xFFFEE2E2), const Color(0xFFB91C1C)),
-      BadgeStyle.neutral => (const Color(0xFFEFEFEF), const Color(0xFFAAAAAA)),
+      BadgeStyle.neutral => (const Color(0xFF252525), const Color(0xFFAAAAAA)),
     };
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 3),
@@ -59,7 +60,7 @@ class InspectorBadge extends StatelessWidget {
         color: bg,
         borderRadius: BorderRadius.circular(20),
         border: style == BadgeStyle.neutral
-            ? Border.all(color: const Color(0xFFE0E0E0), width: 0.5)
+            ? Border.all(color: const Color(0xFF3A3A3A), width: 0.5)
             : null,
       ),
       child: Text(
@@ -81,13 +82,13 @@ class MonoPreview extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.all(12),
-      color: const Color(0xFFF0F0F0),
+      color: const Color(0xFF111111),
       child: Text(
         text,
         style: const TextStyle(
           fontFamily: 'monospace',
           fontSize: 10.5,
-          color: Color(0xFF333333),
+          color: Color(0xFFB8C4E0),
           height: 1.5,
         ),
       ),

--- a/lib/features/detection_inspector/widgets/di_score_preview.dart
+++ b/lib/features/detection_inspector/widgets/di_score_preview.dart
@@ -23,7 +23,7 @@ class DiScorePreview extends StatelessWidget {
         children: [
           ScoreNotationViewer(
             score: score,
-            backgroundColor: const Color(0xFF0B0E16),
+            backgroundColor: const Color(0xFFF9FAFB),
           ),
           const SizedBox(height: 12),
           _MonoBlock(text: debug),

--- a/lib/features/musicxml_inspector/music_inspector_screen.dart
+++ b/lib/features/musicxml_inspector/music_inspector_screen.dart
@@ -55,9 +55,9 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
     final isLoading = _controller.isLoading;
 
     return Scaffold(
-      backgroundColor: const Color(0xFFF5F5F5),
+      backgroundColor: const Color(0xFF0D0D0D),
       appBar: AppBar(
-        backgroundColor: const Color(0xFFF5F5F5),
+        backgroundColor: const Color(0xFF0D0D0D),
         elevation: 0,
         centerTitle: true,
         title: const Text(
@@ -65,7 +65,7 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
           style: TextStyle(
             fontSize: 14,
             fontWeight: FontWeight.w600,
-            color: Color(0xFF111111),
+            color: Color(0xFFFFFFFF),
           ),
         ),
         actions: [
@@ -75,9 +75,9 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
             decoration: BoxDecoration(
               color: const Color(0xFFE8F0FE),
               borderRadius: BorderRadius.circular(4),
-            ),
-            child: const Text(
-              'DEV',
+              ),
+              child: const Text(
+                'DEV',
               style: TextStyle(
                 fontSize: 10,
                 fontWeight: FontWeight.w600,
@@ -96,10 +96,10 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
             ElevatedButton(
               onPressed: isLoading ? null : _onImportPressed,
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF185FA5),
+                backgroundColor: const Color(0xFFD4A96A),
                 foregroundColor: Colors.white,
                 disabledBackgroundColor:
-                    const Color(0xFF185FA5).withValues(alpha: 0.5),
+                    const Color(0xFFD4A96A).withValues(alpha: 0.5),
                 padding: const EdgeInsets.symmetric(vertical: 14),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10),
@@ -133,8 +133,8 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
                 style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
               ),
               style: OutlinedButton.styleFrom(
-                foregroundColor: const Color(0xFF185FA5),
-                side: const BorderSide(color: Color(0xFF185FA5), width: 1.5),
+                foregroundColor: const Color(0xFFD4A96A),
+                side: const BorderSide(color: Color(0xFFD4A96A), width: 1.5),
                 padding: const EdgeInsets.symmetric(vertical: 14),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10),

--- a/lib/features/musicxml_inspector/widgets/collapsible_section.dart
+++ b/lib/features/musicxml_inspector/widgets/collapsible_section.dart
@@ -22,9 +22,9 @@ class CollapsibleSection extends StatelessWidget {
       opacity: enabled ? 1.0 : 0.45,
       child: Container(
         decoration: BoxDecoration(
-          color: const Color(0xFFF7F7F7),
+          color: const Color(0xFF1A1A1A),
           borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: const Color(0xFFE8E8E8), width: 0.5),
+          border: Border.all(color: const Color(0xFF2C2C2C), width: 0.5),
         ),
         child: Column(
           children: [
@@ -41,7 +41,7 @@ class CollapsibleSection extends StatelessWidget {
                       style: const TextStyle(
                         fontSize: 10,
                         fontWeight: FontWeight.w600,
-                        color: Color(0xFF999999),
+                        color: Color(0xFF8A8A8A),
                         letterSpacing: 0.8,
                       ),
                     ),
@@ -50,7 +50,7 @@ class CollapsibleSection extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 11,
                         color: enabled
-                            ? const Color(0xFF185FA5)
+                            ? const Color(0xFFD4A96A)
                             : const Color(0xFFBBBBBB),
                         fontWeight: FontWeight.w500,
                       ),

--- a/lib/features/musicxml_inspector/widgets/counts_section.dart
+++ b/lib/features/musicxml_inspector/widgets/counts_section.dart
@@ -71,8 +71,9 @@ class CountCard extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 10),
         decoration: BoxDecoration(
-          color: const Color(0xFFF7F7F7),
+          color: const Color(0xFF1A1A1A),
           borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: const Color(0xFF2C2C2C), width: 0.5),
         ),
         child: Column(
           children: [
@@ -81,13 +82,13 @@ class CountCard extends StatelessWidget {
               style: const TextStyle(
                 fontSize: 20,
                 fontWeight: FontWeight.w600,
-                color: Color(0xFF111111),
+                color: Color(0xFFFFFFFF),
               ),
             ),
             const SizedBox(height: 2),
             Text(
               label,
-              style: const TextStyle(fontSize: 10, color: Color(0xFF999999)),
+              style: const TextStyle(fontSize: 10, color: Color(0xFF8A8A8A)),
             ),
           ],
         ),

--- a/lib/features/musicxml_inspector/widgets/error_block.dart
+++ b/lib/features/musicxml_inspector/widgets/error_block.dart
@@ -17,16 +17,16 @@ class ErrorBlock extends StatelessWidget {
     // Validation errors use orange; hard parse errors use red.
     final (bg, border, labelColor, textColor) = isValidation
         ? (
-            const Color(0xFFFFF7ED),
-            const Color(0xFFFED7AA),
-            const Color(0xFFC2410C),
-            const Color(0xFF7C2D12),
+            const Color(0xFF2B1E10),
+            const Color(0xFF7C4A1D),
+            const Color(0xFFF59E0B),
+            const Color(0xFFFCD9A3),
           )
         : (
-            const Color(0xFFFFF5F5),
-            const Color(0xFFFCA5A5),
-            const Color(0xFFB91C1C),
+            const Color(0xFF2A1717),
             const Color(0xFF7F1D1D),
+            const Color(0xFFF87171),
+            const Color(0xFFFECACA),
           );
 
     return Container(
@@ -76,9 +76,9 @@ class WarningBlock extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: const Color(0xFFFFFBEB),
+        color: const Color(0xFF2D2615),
         borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: const Color(0xFFFDE68A), width: 0.5),
+        border: Border.all(color: const Color(0xFF8D6C1E), width: 0.5),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -88,7 +88,7 @@ class WarningBlock extends StatelessWidget {
             style: TextStyle(
               fontSize: 10,
               fontWeight: FontWeight.w600,
-              color: Color(0xFFB45309),
+              color: Color(0xFFF59E0B),
               letterSpacing: 0.8,
             ),
           ),
@@ -100,7 +100,7 @@ class WarningBlock extends StatelessWidget {
                 '• $w',
                 style: const TextStyle(
                   fontSize: 11.5,
-                  color: Color(0xFF78350F),
+                  color: Color(0xFFFDE68A),
                   height: 1.55,
                 ),
               ),

--- a/lib/features/musicxml_inspector/widgets/metadata_section.dart
+++ b/lib/features/musicxml_inspector/widgets/metadata_section.dart
@@ -51,7 +51,7 @@ class MetaRow extends StatelessWidget {
               isEmpty ? '—' : value!,
               style: TextStyle(
                 fontSize: mono ? 11 : 12,
-                color: isEmpty ? const Color(0xFFBBBBBB) : const Color(0xFF111111),
+                color: isEmpty ? const Color(0xFFBBBBBB) : const Color(0xFFFFFFFF),
                 fontStyle: isEmpty ? FontStyle.italic : FontStyle.normal,
                 fontFamily: mono ? 'monospace' : null,
               ),

--- a/lib/features/musicxml_inspector/widgets/status_section.dart
+++ b/lib/features/musicxml_inspector/widgets/status_section.dart
@@ -29,7 +29,7 @@ class StatusSection extends StatelessWidget {
                         : FontWeight.w500,
                     color: state.status == ScreenState.empty
                         ? const Color(0xFFAAAAAA)
-                        : const Color(0xFF111111),
+                        : const Color(0xFFFFFFFF),
                     fontStyle: state.status == ScreenState.empty
                         ? FontStyle.italic
                         : FontStyle.normal,

--- a/lib/features/scan/presentation/scan_screen.dart
+++ b/lib/features/scan/presentation/scan_screen.dart
@@ -70,9 +70,9 @@ class _ScanScreenState extends State<ScanScreen> {
         centerTitle: true,
         actions: [
           IconButton(
-            tooltip: 'Import MusicXML/JSON',
-            onPressed: _importFromFile,
-            icon: const Icon(Icons.file_upload_outlined),
+            tooltip: 'Scan / Import',
+            onPressed: () => _showInputChooser(context),
+            icon: const Icon(Icons.add_photo_alternate_outlined),
           ),
         ],
       ),
@@ -111,8 +111,8 @@ class _ScanScreenState extends State<ScanScreen> {
               padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
               child: ScanActions(
           onRedo: () => Navigator.pop(context),
-          onImport: _importFromFile,
-          onContinue: () {
+          onImport: () => _showInputChooser(context),
+          onContinue: vm.result!.hasDetections ? () {
             final mappedScore = vm.mappingResult?.score ??
                 const Score(
                   id: 'scan-score',
@@ -135,7 +135,7 @@ class _ScanScreenState extends State<ScanScreen> {
                 initialState: EditorState(score: mappedScore),
               ),
             );
-          },
+          } : null,
               ),
             ),
           ],
@@ -144,12 +144,93 @@ class _ScanScreenState extends State<ScanScreen> {
     );
   }
 
-  Future<void> _importFromFile() async {
+  Future<void> _showInputChooser(BuildContext context) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: const Color(0xFF111111),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 16, 20, 18),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Choose input source',
+                  style: TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                _SourceOption(
+                  icon: Icons.photo_camera_outlined,
+                  label: 'Capture image',
+                  onTap: () {
+                    Navigator.pop(sheetContext);
+                    Navigator.pop(context);
+                  },
+                ),
+                _SourceOption(
+                  icon: Icons.image_outlined,
+                  label: 'Import image (detect symbols)',
+                  onTap: () {
+                    Navigator.pop(sheetContext);
+                    _importImageForDetection();
+                  },
+                ),
+                _SourceOption(
+                  icon: Icons.description_outlined,
+                  label: 'Import MusicXML',
+                  onTap: () {
+                    Navigator.pop(sheetContext);
+                    _importStructuredFile(allowedExtensions: const ['xml', 'musicxml']);
+                  },
+                ),
+                _SourceOption(
+                  icon: Icons.data_object_outlined,
+                  label: 'Import score JSON',
+                  onTap: () {
+                    Navigator.pop(sheetContext);
+                    _importStructuredFile(allowedExtensions: const ['json']);
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _importImageForDetection() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.image,
+      allowMultiple: false,
+      withData: true,
+    );
+    if (!mounted || result == null || result.files.isEmpty) return;
+    final data = result.files.single.bytes;
+    if (data == null) {
+      _showImportError('Unable to read the selected image.');
+      return;
+    }
+    await context.read<ScanViewModel>().run(data);
+  }
+
+  Future<void> _importStructuredFile({
+    required List<String> allowedExtensions,
+  }) async {
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
       allowMultiple: false,
       withData: true,
-      allowedExtensions: const ['json', 'xml', 'musicxml'],
+      allowedExtensions: allowedExtensions,
     );
 
     if (!mounted || result == null || result.files.isEmpty) return;
@@ -383,6 +464,51 @@ class _ScanScreenState extends State<ScanScreen> {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SourceOption extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  const _SourceOption({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Ink(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          decoration: BoxDecoration(
+            color: const Color(0xFF1A1A1A),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: const Color(0xFF2C2C2C)),
+          ),
+          child: Row(
+            children: [
+              Icon(icon, size: 18, color: AppColors.textSecondary),
+              const SizedBox(width: 10),
+              Text(
+                label,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/scan/presentation/widgets/scan_actions.dart
+++ b/lib/features/scan/presentation/widgets/scan_actions.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 class ScanActions extends StatelessWidget {
   final VoidCallback onRedo;
-  final VoidCallback onContinue;
+  final VoidCallback? onContinue;
   final VoidCallback? onImport;
 
   const ScanActions({
@@ -19,6 +19,7 @@ class ScanActions extends StatelessWidget {
   static const _accent      = Color(0xFFD4A96A);
   static const _textPrimary = Color(0xFFFFFFFF);
   static const _textMuted   = Color(0xFF8A8A8A);
+  static const _disabledBg  = Color(0xFF2A2A2A);
 
   @override
   Widget build(BuildContext context) {
@@ -103,17 +104,19 @@ class ScanActions extends StatelessWidget {
               child: Container(
                 height: 52,
                 decoration: BoxDecoration(
-                  color: _textPrimary,
+                  color: onContinue == null ? _disabledBg : _textPrimary,
                   borderRadius: BorderRadius.circular(14),
-                  boxShadow: [
-                    BoxShadow(
-                      color: _accent.withValues(alpha: 0.18),
-                      blurRadius: 20,
-                      offset: const Offset(0, 6),
-                    ),
-                  ],
+                  boxShadow: onContinue == null
+                      ? null
+                      : [
+                          BoxShadow(
+                            color: _accent.withValues(alpha: 0.18),
+                            blurRadius: 20,
+                            offset: const Offset(0, 6),
+                          ),
+                        ],
                 ),
-                child: const Row(
+                child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     Text(
@@ -121,12 +124,16 @@ class ScanActions extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 14,
                         fontWeight: FontWeight.w600,
-                        color: _bg,
+                        color: onContinue == null ? _textMuted : _bg,
                         letterSpacing: 0.3,
                       ),
                     ),
                     SizedBox(width: 8),
-                    Icon(Icons.arrow_forward, size: 18, color: _bg),
+                    Icon(
+                      Icons.arrow_forward,
+                      size: 18,
+                      color: onContinue == null ? _textMuted : _bg,
+                    ),
                   ],
                 ),
               ),
@@ -142,7 +149,7 @@ class ScanActions extends StatelessWidget {
 
 class _TappableButton extends StatefulWidget {
   final Widget child;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   const _TappableButton({required this.child, required this.onPressed});
 
@@ -156,17 +163,18 @@ class _TappableButtonState extends State<_TappableButton> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTapDown: (_) => setState(() => _pressed = true),
+      onTapDown: widget.onPressed == null ? null : (_) => setState(() => _pressed = true),
       onTapUp: (_) {
+        if (widget.onPressed == null) return;
         setState(() => _pressed = false);
-        widget.onPressed();
+        widget.onPressed?.call();
       },
-      onTapCancel: () => setState(() => _pressed = false),
+      onTapCancel: widget.onPressed == null ? null : () => setState(() => _pressed = false),
       child: AnimatedScale(
-        scale: _pressed ? 0.97 : 1.0,
+        scale: _pressed && widget.onPressed != null ? 0.97 : 1.0,
         duration: const Duration(milliseconds: 100),
         child: AnimatedOpacity(
-          opacity: _pressed ? 0.85 : 1.0,
+          opacity: widget.onPressed == null ? 0.55 : (_pressed ? 0.85 : 1.0),
           duration: const Duration(milliseconds: 100),
           child: widget.child,
         ),


### PR DESCRIPTION
### Motivation
- Prevent users from advancing to the editor with an empty detection result by disabling the scan "Continue" action when no symbols are detected. 
- Provide a clearer input workflow so users can choose whether to capture an image, import an image to re-run detection, or import structured score files (MusicXML / JSON). 
- Improve detection preview readability and make the MusicXML inspector visually consistent with the app dark theme for the Dev Workbench.

### Description
- Make `ScanActions.onContinue` nullable and render a disabled visual state when `onContinue == null`, and update the tappable wrapper to safely handle a nullable `onPressed`. (`lib/features/scan/presentation/widgets/scan_actions.dart`) 
- Add an input-source chooser bottom sheet (capture image, import image for detection, import MusicXML, import JSON) exposed from the app bar and the scan action bar, and wire the import-image path to re-run detection via `ScanViewModel.run`. (`lib/features/scan/presentation/scan_screen.dart`) 
- Guard navigation to the editor by passing `null` for `onContinue` when `vm.result!.hasDetections` is false. (`lib/features/scan/presentation/scan_screen.dart`) 
- Switch the Detection Inspector score preview to a light notation background to make the rendered score visible. (`lib/features/detection_inspector/widgets/di_score_preview.dart`) 
- Convert MusicXML inspector surface, cards, collapsible sections, mono previews, count cards, and warning/error blocks to dark-theme colors and adjust accents to match app styling. (`lib/core/widgets/inspector_shared_widgets.dart`, `lib/features/musicxml_inspector/*`) 

### Testing
- Ran `git diff --check` which passed. 
- Attempted to run code formatting with `dart format` and inspect the Flutter SDK with `flutter --version`, but both toolchain commands could not run in this environment because the `dart`/`flutter` CLIs are not available (formatting/tests were not executed). 
- Verified code compiles locally was not performed here due to missing toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c796bd4fbc8320a526d2e5fa9922b3)