### PR TITLE
Add Import Score screen (MusicXML + DEV JSON) and disable Continue when no detections

### DIFF
--- a/lib/features/capture/presentation/capture_screen.dart
+++ b/lib/features/capture/presentation/capture_screen.dart
@@ -336,13 +336,9 @@ class _CaptureScreenState extends State<CaptureScreen>
         backgroundColor: _bg,
         elevation: 0,
         surfaceTintColor: Colors.transparent,
-        leading: Padding(
-          padding: const EdgeInsets.only(left: 16),
-          child: Image.asset(
-            'assets/images/notevision.png',
-            height: 28,
-            colorBlendMode: BlendMode.srcIn,
-          ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new, size: 20, color: _textPrimary),
+          onPressed: () => Navigator.of(context).maybePop(),
         ),
         title: const Text(
           'Note Vision',
@@ -507,7 +503,7 @@ class _BottomNavItem extends StatelessWidget {
 
 class _TappableButton extends StatefulWidget {
   final Widget child;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   const _TappableButton({required this.child, required this.onPressed});
 
@@ -521,12 +517,14 @@ class _TappableButtonState extends State<_TappableButton> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTapDown: (_) => setState(() => _pressed = true),
-      onTapUp: (_) {
-        setState(() => _pressed = false);
-        widget.onPressed();
-      },
-      onTapCancel: () => setState(() => _pressed = false),
+      onTapDown: widget.onPressed == null ? null : (_) => setState(() => _pressed = true),
+      onTapCancel: widget.onPressed == null ? null : () => setState(() => _pressed = false),
+      onTap: widget.onPressed == null
+          ? null
+          : () {
+              setState(() => _pressed = false);
+              widget.onPressed!();
+            },
       child: AnimatedScale(
         scale: _pressed ? 0.97 : 1.0,
         duration: const Duration(milliseconds: 100),

--- a/lib/features/capture/presentation/capture_screen.dart
+++ b/lib/features/capture/presentation/capture_screen.dart
@@ -308,15 +308,19 @@ class _CaptureScreenState extends State<CaptureScreen>
         const SizedBox(height: 10),
         _TappableButton(
           onPressed: _cancelSelection,
-          child: SizedBox(
+          child: Container(
             width: double.infinity,
-            height: 44,
-            child: Center(
+            height: 52,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: _border, width: 1),
+            ),
+            child: const Center(
               child: Text(
                 'Cancel',
                 style: TextStyle(
                   fontSize: 13,
-                  color: const Color.fromARGB(255, 255, 255, 255).withValues(alpha: 0.7),
+                  color: _textSecondary,
                   letterSpacing: 0.3,
                 ),
               ),

--- a/lib/features/capture/presentation/capture_screen.dart
+++ b/lib/features/capture/presentation/capture_screen.dart
@@ -363,54 +363,70 @@ class _CaptureScreenState extends State<CaptureScreen>
           ),
         ],
       ),
-      body: Padding(
-        padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // ── Section label ────────────────────────────────────────────
-            const Text(
-              'CAPTURE MUSIC SHEET',
-              style: TextStyle(
-                fontSize: 11,
-                fontWeight: FontWeight.w600,
-                color: _textSecondary,
-                letterSpacing: 2.0,
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final isLandscape = constraints.maxWidth > constraints.maxHeight;
+          if (isLandscape) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildHeaderSection(),
+                  const SizedBox(height: 14),
+                  SizedBox(height: 260, child: _buildPreviewArea()),
+                  const SizedBox(height: 14),
+                  _buildActionRow(),
+                ],
               ),
+            );
+          }
+
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildHeaderSection(),
+                const SizedBox(height: 20),
+                Expanded(child: _buildPreviewArea()),
+                const SizedBox(height: 16),
+                _buildActionRow(),
+                const SizedBox(height: 20),
+              ],
             ),
-
-            const SizedBox(height: 6),
-
-            // ── Description ──────────────────────────────────────────────
-            const Text(
-              'Scan printed music sheets and convert them into digital notation.',
-              style: TextStyle(
-                fontSize: 14,
-                color: _textSecondary,
-                height: 1.5,
-              ),
-            ),
-
-            const SizedBox(height: 16),
-
-            // ── Hint ─────────────────────────────────────────────────────
-            _buildHint(),
-
-            const SizedBox(height: 20),
-
-            // ── Preview area ─────────────────────────────────────────────
-            Expanded(child: _buildPreviewArea()),
-
-            const SizedBox(height: 16),
-
-            // ── Action buttons ───────────────────────────────────────────
-            _buildActionRow(),
-
-            const SizedBox(height: 20),
-          ],
-        ),
+          );
+        },
       ),
       bottomNavigationBar: _buildBottomNav(),
+    );
+  }
+
+  Widget _buildHeaderSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'CAPTURE MUSIC SHEET',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color: _textSecondary,
+            letterSpacing: 2.0,
+          ),
+        ),
+        const SizedBox(height: 6),
+        const Text(
+          'Scan printed music sheets and convert them into digital notation.',
+          style: TextStyle(
+            fontSize: 14,
+            color: _textSecondary,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 16),
+        _buildHint(),
+      ],
     );
   }
 

--- a/lib/features/capture/presentation/capture_screen.dart
+++ b/lib/features/capture/presentation/capture_screen.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:note_vision/core/utils/image_picker_helper.dart';
 import 'package:note_vision/core/widgets/drawer.dart';
 import 'package:note_vision/features/scan/presentation/scan_screen.dart';
+import 'package:note_vision/features/capture/presentation/import_score_screen.dart';
 
 class CaptureScreen extends StatefulWidget {
   const CaptureScreen({super.key});
@@ -435,7 +436,14 @@ class _CaptureScreenState extends State<CaptureScreen>
                 icon: Icons.upload_file_outlined,
                 label: 'Import',
                 isSelected: false,
-                onTap: _pickFromGallery,
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const ImportScoreScreen(),
+                    ),
+                  );
+                },
               ),
             ],
           ),

--- a/lib/features/capture/presentation/capture_screen.dart
+++ b/lib/features/capture/presentation/capture_screen.dart
@@ -430,14 +430,14 @@ class _CaptureScreenState extends State<CaptureScreen>
                 icon: Icons.camera_alt_outlined,
                 label: 'Scan',
                 isSelected: true,
-                onTap: _openCameraAndShowPreview,
+                onTap: () {},
               ),
               _BottomNavItem(
                 icon: Icons.upload_file_outlined,
                 label: 'Import',
                 isSelected: false,
                 onTap: () {
-                  Navigator.push(
+                  Navigator.pushReplacement(
                     context,
                     MaterialPageRoute(
                       builder: (_) => const ImportScoreScreen(),

--- a/lib/features/capture/presentation/import_score_screen.dart
+++ b/lib/features/capture/presentation/import_score_screen.dart
@@ -235,15 +235,19 @@ class _ImportScoreScreenState extends State<ImportScoreScreen> {
           const SizedBox(height: 10),
           _TappableButton(
             onPressed: _cancelSelection,
-            child: SizedBox(
+            child: Container(
               width: double.infinity,
-              height: 44,
-              child: Center(
+              height: 52,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(14),
+                border: Border.all(color: _border, width: 1),
+              ),
+              child: const Center(
                 child: Text(
                   'Cancel',
                   style: TextStyle(
                     fontSize: 13,
-                    color: Colors.white.withValues(alpha: 0.7),
+                    color: _textSecondary,
                     letterSpacing: 0.3,
                   ),
                 ),

--- a/lib/features/capture/presentation/import_score_screen.dart
+++ b/lib/features/capture/presentation/import_score_screen.dart
@@ -727,13 +727,13 @@ class _TappableButtonState extends State<_TappableButton> {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTapDown: widget.onPressed == null ? null : (_) => setState(() => _pressed = true),
-      onTapUp: widget.onPressed == null
+      onTapCancel: widget.onPressed == null ? null : () => setState(() => _pressed = false),
+      onTap: widget.onPressed == null
           ? null
-          : (_) {
+          : () {
               setState(() => _pressed = false);
               widget.onPressed!();
             },
-      onTapCancel: widget.onPressed == null ? null : () => setState(() => _pressed = false),
       child: AnimatedScale(
         scale: _pressed ? 0.97 : 1.0,
         duration: const Duration(milliseconds: 100),

--- a/lib/features/capture/presentation/import_score_screen.dart
+++ b/lib/features/capture/presentation/import_score_screen.dart
@@ -8,13 +8,14 @@ import 'package:note_vision/core/models/part.dart';
 import 'package:note_vision/core/models/rest.dart';
 import 'package:note_vision/core/models/score.dart';
 import 'package:note_vision/core/models/score_symbol.dart';
-import 'package:note_vision/core/theme/app_theme.dart';
-import 'package:note_vision/core/widgets/score_notation_viewer.dart';
+import 'package:note_vision/features/collection/presentation/collection_screen.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
 import 'package:note_vision/features/editor/presentation/editor_shell_screen.dart';
 import 'package:note_vision/features/musicXML/musicxml_parser_service.dart';
 import 'package:note_vision/features/musicXML/musicxml_score_converter.dart';
 import 'package:note_vision/features/musicXML/musicxml_validator_service.dart';
+import 'package:note_vision/core/widgets/score_notation_viewer.dart';
+import 'package:note_vision/features/capture/presentation/capture_screen.dart';
 
 class ImportScoreScreen extends StatefulWidget {
   const ImportScoreScreen({super.key});
@@ -28,123 +29,150 @@ class _ImportScoreScreenState extends State<ImportScoreScreen> {
   static const _xmlConverter = MusicXmlScoreConverter();
   static const _xmlValidator = MusicXmlValidatorService();
 
+  static const _bg = Color(0xFF0D0D0D);
+  static const _surface = Color(0xFF1A1A1A);
+  static const _border = Color(0xFF2C2C2C);
+  static const _accent = Color(0xFFD4A96A);
+  static const _textPrimary = Color(0xFFFFFFFF);
+  static const _textSecondary = Color(0xFF8A8A8A);
+
+  bool _isLoading = false;
   Score? _importedScore;
   String? _selectedFileName;
   List<String> _errors = const [];
   List<String> _warnings = const [];
-  bool _isLoading = false;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.background,
+      backgroundColor: _bg,
       appBar: AppBar(
+        backgroundColor: _bg,
+        elevation: 0,
+        surfaceTintColor: Colors.transparent,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new, size: 20, color: _textPrimary),
+          onPressed: _goToCollection,
+        ),
         title: const Text(
-          'Import Score',
+          'Note Vision',
           style: TextStyle(
-            color: AppColors.textPrimary,
-            fontWeight: FontWeight.w600,
+            fontFamily: 'MaturaMTScriptCapitals',
+            fontSize: 22,
+            color: _textPrimary,
+            letterSpacing: 0.5,
           ),
         ),
         centerTitle: true,
       ),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              _buildImportActions(),
-              const SizedBox(height: 14),
-              if (_selectedFileName != null)
-                Text(
-                  'Selected: $_selectedFileName',
-                  style: const TextStyle(
-                    color: AppColors.textSecondary,
-                    fontSize: 12,
-                  ),
-                ),
-              if (_warnings.isNotEmpty) ...[
-                const SizedBox(height: 12),
-                _buildMessageCard(
-                  title: 'Warnings',
-                  color: Colors.amber,
-                  messages: _warnings,
-                ),
-              ],
-              if (_errors.isNotEmpty) ...[
-                const SizedBox(height: 12),
-                _buildMessageCard(
-                  title: 'Import issues',
-                  color: const Color(0xFFEF4444),
-                  messages: _errors,
-                ),
-              ],
-              const SizedBox(height: 12),
-              Expanded(
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: AppColors.surface,
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(color: AppColors.border),
-                  ),
-                  clipBehavior: Clip.antiAlias,
-                  child: _importedScore == null
-                      ? const Center(
-                          child: Text(
-                            'Import a MusicXML file to preview notation.',
-                            style: TextStyle(color: AppColors.textSecondary),
-                          ),
-                        )
-                      : ScoreNotationViewer(
-                          score: _importedScore,
-                          backgroundColor: const Color(0xFFF9FAFB),
-                        ),
-                ),
+      body: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'IMPORT SCORE FILE',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+                color: _textSecondary,
+                letterSpacing: 2.0,
               ),
-              const SizedBox(height: 14),
-              FilledButton(
-                onPressed: (_isLoading || _importedScore == null)
-                    ? null
-                    : _continueToEditor,
-                style: FilledButton.styleFrom(
-                  backgroundColor: AppColors.textPrimary,
-                  foregroundColor: AppColors.background,
-                  disabledBackgroundColor: AppColors.border,
-                  disabledForegroundColor: AppColors.textSecondary,
-                  minimumSize: const Size.fromHeight(52),
-                ),
-                child: const Text('Continue'),
+            ),
+            const SizedBox(height: 6),
+            const Text(
+              'Import a MusicXML file, preview it, then continue to the editor.',
+              style: TextStyle(
+                fontSize: 14,
+                color: _textSecondary,
+                height: 1.5,
               ),
+            ),
+            const SizedBox(height: 18),
+            Expanded(child: _buildPreviewArea()),
+            const SizedBox(height: 14),
+            if (_warnings.isNotEmpty) ...[
+              _buildMessageCard(
+                title: 'Warnings',
+                icon: Icons.info_outline,
+                color: _accent,
+                messages: _warnings,
+              ),
+              const SizedBox(height: 10),
             ],
-          ),
+            if (_errors.isNotEmpty) ...[
+              _buildMessageCard(
+                title: 'Import Issues',
+                icon: Icons.error_outline,
+                color: const Color(0xFFFF6B6B),
+                messages: _errors,
+              ),
+              const SizedBox(height: 10),
+            ],
+            _buildActionRow(),
+            const SizedBox(height: 20),
+          ],
         ),
+      ),
+      bottomNavigationBar: _buildBottomNav(),
+    );
+  }
+
+  Widget _buildPreviewArea() {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: _surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: _border),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: AspectRatio(
+        aspectRatio: 3 / 4,
+        child: _importedScore != null
+            ? ScoreNotationViewer(
+                score: _importedScore,
+                backgroundColor: const Color(0xFFF9FAFB),
+              )
+            : _buildEmptyPreview(),
       ),
     );
   }
 
-  Widget _buildImportActions() {
-    return Row(
+  Widget _buildEmptyPreview() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Expanded(
-          child: OutlinedButton.icon(
-            onPressed: _isLoading ? null : _importMusicXml,
-            icon: _isLoading
-                ? const SizedBox(
-                    height: 16,
-                    width: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.music_note_outlined),
-            label: const Text('Import MusicXML'),
+        Container(
+          width: 64,
+          height: 64,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(color: _border, width: 1.5),
+          ),
+          child: const Icon(
+            Icons.library_music_outlined,
+            color: _textSecondary,
+            size: 28,
           ),
         ),
-        const SizedBox(width: 10),
-        Expanded(
-          child: OutlinedButton.icon(
-            onPressed: _isLoading ? null : _importJson,
-            icon: const Icon(Icons.developer_mode_outlined),
-            label: const Text('Import JSON (DEV)'),
+        const SizedBox(height: 16),
+        const Text(
+          'No score imported',
+          style: TextStyle(
+            fontSize: 14,
+            color: _textSecondary,
+            letterSpacing: 0.3,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          _selectedFileName == null
+              ? 'Import MusicXML or JSON (DEV) below'
+              : 'Selected: $_selectedFileName',
+          style: TextStyle(
+            fontSize: 12,
+            color: _textSecondary.withValues(alpha: 0.6),
           ),
         ),
       ],
@@ -153,37 +181,242 @@ class _ImportScoreScreenState extends State<ImportScoreScreen> {
 
   Widget _buildMessageCard({
     required String title,
+    required IconData icon,
     required Color color,
     required List<String> messages,
   }) {
     return Container(
+      width: double.infinity,
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: color.withValues(alpha: 0.4)),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.35)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            title,
-            style: TextStyle(color: color, fontWeight: FontWeight.w600),
+          Row(
+            children: [
+              Icon(icon, size: 15, color: color),
+              const SizedBox(width: 6),
+              Text(
+                title,
+                style: TextStyle(
+                  color: color,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
           ),
           const SizedBox(height: 6),
           for (final message in messages)
             Padding(
-              padding: const EdgeInsets.only(bottom: 3),
+              padding: const EdgeInsets.only(bottom: 4),
               child: Text(
                 '• $message',
                 style: const TextStyle(
-                  color: AppColors.textPrimary,
                   fontSize: 12,
-                  height: 1.35,
+                  color: _textPrimary,
+                  height: 1.4,
                 ),
               ),
             ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildActionRow() {
+    if (_importedScore != null) {
+      return Column(
+        children: [
+          _buildContinueButton(),
+          const SizedBox(height: 10),
+          _TappableButton(
+            onPressed: _cancelSelection,
+            child: SizedBox(
+              width: double.infinity,
+              height: 44,
+              child: Center(
+                child: Text(
+                  'Cancel',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: Colors.white.withValues(alpha: 0.7),
+                    letterSpacing: 0.3,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Row(
+      children: [
+        _buildPrimaryButton(
+          label: 'Import MusicXML',
+          icon: Icons.library_music_outlined,
+          onPressed: _isLoading ? null : _importMusicXml,
+        ),
+        const SizedBox(width: 12),
+        _buildGhostButton(
+          label: 'Import JSON (DEV)',
+          icon: Icons.developer_mode_outlined,
+          onPressed: _isLoading ? null : _importJson,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPrimaryButton({
+    required String label,
+    required IconData icon,
+    required VoidCallback? onPressed,
+  }) {
+    return Expanded(
+      child: _TappableButton(
+        onPressed: onPressed,
+        child: Container(
+          height: 52,
+          decoration: BoxDecoration(
+            color: onPressed == null ? _border : _textPrimary,
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (_isLoading)
+                const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2, color: _bg),
+                )
+              else
+                Icon(icon, size: 18, color: _bg),
+              const SizedBox(width: 8),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: onPressed == null ? _textSecondary : _bg,
+                  letterSpacing: 0.2,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGhostButton({
+    required String label,
+    required IconData icon,
+    required VoidCallback? onPressed,
+  }) {
+    return Expanded(
+      child: _TappableButton(
+        onPressed: onPressed,
+        child: Container(
+          height: 52,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: _border, width: 1),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, size: 18, color: _textSecondary),
+              const SizedBox(width: 8),
+              Text(
+                label,
+                style: const TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w400,
+                  color: _textSecondary,
+                  letterSpacing: 0.2,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContinueButton() {
+    return _TappableButton(
+      onPressed: _continueToEditor,
+      child: Container(
+        width: double.infinity,
+        height: 52,
+        decoration: BoxDecoration(
+          color: _textPrimary,
+          borderRadius: BorderRadius.circular(14),
+          boxShadow: [
+            BoxShadow(
+              color: _accent.withValues(alpha: 0.15),
+              blurRadius: 20,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        child: const Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'Continue',
+              style: TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: _bg,
+                letterSpacing: 0.4,
+              ),
+            ),
+            SizedBox(width: 8),
+            Icon(Icons.arrow_forward, size: 18, color: _bg),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBottomNav() {
+    return Container(
+      decoration: const BoxDecoration(
+        color: _surface,
+        border: Border(top: BorderSide(color: _border, width: 0.5)),
+      ),
+      child: SafeArea(
+        top: false,
+        child: SizedBox(
+          height: 60,
+          child: Row(
+            children: [
+              _BottomNavItem(
+                icon: Icons.camera_alt_outlined,
+                label: 'Scan',
+                isSelected: false,
+                onTap: () {
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(builder: (_) => const CaptureScreen()),
+                  );
+                },
+              ),
+              _BottomNavItem(
+                icon: Icons.upload_file_outlined,
+                label: 'Import',
+                isSelected: true,
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
@@ -210,8 +443,8 @@ class _ImportScoreScreenState extends State<ImportScoreScreen> {
     }
 
     final file = result.files.single;
-    final data = file.bytes;
-    if (data == null) {
+    final bytes = file.bytes;
+    if (bytes == null) {
       setState(() {
         _isLoading = false;
         _selectedFileName = file.name;
@@ -221,8 +454,7 @@ class _ImportScoreScreenState extends State<ImportScoreScreen> {
     }
 
     try {
-      final xmlContent = utf8.decode(data);
-      final parsed = _xmlParser.parse(xmlContent);
+      final parsed = _xmlParser.parse(utf8.decode(bytes));
       if (!parsed.success || parsed.document == null) {
         setState(() {
           _selectedFileName = file.name;
@@ -246,12 +478,11 @@ class _ImportScoreScreenState extends State<ImportScoreScreen> {
         return;
       }
 
-      final score = _xmlConverter.convert(parsed.document!);
       setState(() {
         _selectedFileName = file.name;
         _errors = const [];
         _warnings = validation.warnings;
-        _importedScore = score;
+        _importedScore = _xmlConverter.convert(parsed.document!);
         _isLoading = false;
       });
     } catch (_) {
@@ -307,6 +538,37 @@ class _ImportScoreScreenState extends State<ImportScoreScreen> {
         _warnings = const [];
       });
     }
+  }
+
+  void _cancelSelection() {
+    setState(() {
+      _importedScore = null;
+      _errors = const [];
+      _warnings = const [];
+      _selectedFileName = null;
+    });
+  }
+
+  void _continueToEditor() {
+    final score = _importedScore;
+    if (score == null) return;
+
+    Navigator.pushNamed(
+      context,
+      EditorShellScreen.routeName,
+      arguments: EditorShellArgs(
+        score: score,
+        initialState: EditorState(score: score),
+      ),
+    );
+  }
+
+  void _goToCollection() {
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(builder: (_) => const CollectionScreen()),
+      (route) => false,
+    );
   }
 
   Score _scoreFromJson(String content) {
@@ -399,17 +661,87 @@ class _ImportScoreScreenState extends State<ImportScoreScreen> {
       staff: (symbol['staff'] as num?)?.toInt(),
     );
   }
+}
 
-  void _continueToEditor() {
-    final score = _importedScore;
-    if (score == null) return;
+class _BottomNavItem extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
 
-    Navigator.pushNamed(
-      context,
-      EditorShellScreen.routeName,
-      arguments: EditorShellArgs(
-        score: score,
-        initialState: EditorState(score: score),
+  const _BottomNavItem({
+    required this.icon,
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  static const _accent = Color(0xFFD4A96A);
+  static const _textSecondary = Color(0xFF8A8A8A);
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              size: 22,
+              color: isSelected ? _accent : _textSecondary,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 11,
+                color: isSelected ? _accent : _textSecondary,
+                fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+                letterSpacing: 0.3,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TappableButton extends StatefulWidget {
+  final Widget child;
+  final VoidCallback? onPressed;
+
+  const _TappableButton({required this.child, required this.onPressed});
+
+  @override
+  State<_TappableButton> createState() => _TappableButtonState();
+}
+
+class _TappableButtonState extends State<_TappableButton> {
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: widget.onPressed == null ? null : (_) => setState(() => _pressed = true),
+      onTapUp: widget.onPressed == null
+          ? null
+          : (_) {
+              setState(() => _pressed = false);
+              widget.onPressed!();
+            },
+      onTapCancel: widget.onPressed == null ? null : () => setState(() => _pressed = false),
+      child: AnimatedScale(
+        scale: _pressed ? 0.97 : 1.0,
+        duration: const Duration(milliseconds: 100),
+        child: AnimatedOpacity(
+          opacity: _pressed ? 0.85 : 1.0,
+          duration: const Duration(milliseconds: 100),
+          child: widget.child,
+        ),
       ),
     );
   }

--- a/lib/features/capture/presentation/import_score_screen.dart
+++ b/lib/features/capture/presentation/import_score_screen.dart
@@ -65,56 +65,129 @@ class _ImportScoreScreenState extends State<ImportScoreScreen> {
         ),
         centerTitle: true,
       ),
-      body: Padding(
-        padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(
-              'IMPORT SCORE FILE',
-              style: TextStyle(
-                fontSize: 11,
-                fontWeight: FontWeight.w600,
-                color: _textSecondary,
-                letterSpacing: 2.0,
-              ),
-            ),
-            const SizedBox(height: 6),
-            const Text(
-              'Import a MusicXML file, preview it, then continue to the editor.',
-              style: TextStyle(
-                fontSize: 14,
-                color: _textSecondary,
-                height: 1.5,
-              ),
-            ),
-            const SizedBox(height: 18),
-            Expanded(child: _buildPreviewArea()),
-            const SizedBox(height: 14),
-            if (_warnings.isNotEmpty) ...[
-              _buildMessageCard(
-                title: 'Warnings',
-                icon: Icons.info_outline,
-                color: _accent,
-                messages: _warnings,
-              ),
-              const SizedBox(height: 10),
-            ],
-            if (_errors.isNotEmpty) ...[
-              _buildMessageCard(
-                title: 'Import Issues',
-                icon: Icons.error_outline,
-                color: const Color(0xFFFF6B6B),
-                messages: _errors,
-              ),
-              const SizedBox(height: 10),
-            ],
-            _buildActionRow(),
-            const SizedBox(height: 20),
-          ],
-        ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final isLandscape = constraints.maxWidth > constraints.maxHeight;
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
+            child: isLandscape
+                ? _buildLandscapeContent()
+                : _buildPortraitContent(),
+          );
+        },
       ),
       bottomNavigationBar: _buildBottomNav(),
+    );
+  }
+
+  Widget _buildPortraitContent() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'IMPORT SCORE FILE',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color: _textSecondary,
+            letterSpacing: 2.0,
+          ),
+        ),
+        const SizedBox(height: 6),
+        const Text(
+          'Import a MusicXML file, preview it, then continue to the editor.',
+          style: TextStyle(
+            fontSize: 14,
+            color: _textSecondary,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 18),
+        Expanded(child: _buildPreviewArea()),
+        const SizedBox(height: 14),
+        _buildMessages(),
+        _buildActionRow(),
+        const SizedBox(height: 20),
+      ],
+    );
+  }
+
+  Widget _buildLandscapeContent() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(
+          flex: 3,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'IMPORT SCORE FILE',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: _textSecondary,
+                  letterSpacing: 2.0,
+                ),
+              ),
+              const SizedBox(height: 6),
+              const Text(
+                'Import a MusicXML file, preview it, then continue to the editor.',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: _textSecondary,
+                  height: 1.4,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Expanded(child: _buildPreviewArea()),
+              const SizedBox(height: 12),
+            ],
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          flex: 2,
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                _buildMessages(),
+                _buildActionRow(),
+                const SizedBox(height: 12),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMessages() {
+    if (_warnings.isEmpty && _errors.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      children: [
+        if (_warnings.isNotEmpty) ...[
+          _buildMessageCard(
+            title: 'Warnings',
+            icon: Icons.info_outline,
+            color: _accent,
+            messages: _warnings,
+          ),
+          const SizedBox(height: 10),
+        ],
+        if (_errors.isNotEmpty) ...[
+          _buildMessageCard(
+            title: 'Import Issues',
+            icon: Icons.error_outline,
+            color: const Color(0xFFFF6B6B),
+            messages: _errors,
+          ),
+          const SizedBox(height: 10),
+        ],
+      ],
     );
   }
 

--- a/lib/features/capture/presentation/import_score_screen.dart
+++ b/lib/features/capture/presentation/import_score_screen.dart
@@ -1,0 +1,416 @@
+import 'dart:convert';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:note_vision/core/models/measure.dart';
+import 'package:note_vision/core/models/note.dart';
+import 'package:note_vision/core/models/part.dart';
+import 'package:note_vision/core/models/rest.dart';
+import 'package:note_vision/core/models/score.dart';
+import 'package:note_vision/core/models/score_symbol.dart';
+import 'package:note_vision/core/theme/app_theme.dart';
+import 'package:note_vision/core/widgets/score_notation_viewer.dart';
+import 'package:note_vision/features/editor/model/editor_state.dart';
+import 'package:note_vision/features/editor/presentation/editor_shell_screen.dart';
+import 'package:note_vision/features/musicXML/musicxml_parser_service.dart';
+import 'package:note_vision/features/musicXML/musicxml_score_converter.dart';
+import 'package:note_vision/features/musicXML/musicxml_validator_service.dart';
+
+class ImportScoreScreen extends StatefulWidget {
+  const ImportScoreScreen({super.key});
+
+  @override
+  State<ImportScoreScreen> createState() => _ImportScoreScreenState();
+}
+
+class _ImportScoreScreenState extends State<ImportScoreScreen> {
+  static const _xmlParser = MusicXmlParserService();
+  static const _xmlConverter = MusicXmlScoreConverter();
+  static const _xmlValidator = MusicXmlValidatorService();
+
+  Score? _importedScore;
+  String? _selectedFileName;
+  List<String> _errors = const [];
+  List<String> _warnings = const [];
+  bool _isLoading = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: const Text(
+          'Import Score',
+          style: TextStyle(
+            color: AppColors.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        centerTitle: true,
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _buildImportActions(),
+              const SizedBox(height: 14),
+              if (_selectedFileName != null)
+                Text(
+                  'Selected: $_selectedFileName',
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 12,
+                  ),
+                ),
+              if (_warnings.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                _buildMessageCard(
+                  title: 'Warnings',
+                  color: Colors.amber,
+                  messages: _warnings,
+                ),
+              ],
+              if (_errors.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                _buildMessageCard(
+                  title: 'Import issues',
+                  color: const Color(0xFFEF4444),
+                  messages: _errors,
+                ),
+              ],
+              const SizedBox(height: 12),
+              Expanded(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: AppColors.surface,
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(color: AppColors.border),
+                  ),
+                  clipBehavior: Clip.antiAlias,
+                  child: _importedScore == null
+                      ? const Center(
+                          child: Text(
+                            'Import a MusicXML file to preview notation.',
+                            style: TextStyle(color: AppColors.textSecondary),
+                          ),
+                        )
+                      : ScoreNotationViewer(
+                          score: _importedScore,
+                          backgroundColor: const Color(0xFFF9FAFB),
+                        ),
+                ),
+              ),
+              const SizedBox(height: 14),
+              FilledButton(
+                onPressed: (_isLoading || _importedScore == null)
+                    ? null
+                    : _continueToEditor,
+                style: FilledButton.styleFrom(
+                  backgroundColor: AppColors.textPrimary,
+                  foregroundColor: AppColors.background,
+                  disabledBackgroundColor: AppColors.border,
+                  disabledForegroundColor: AppColors.textSecondary,
+                  minimumSize: const Size.fromHeight(52),
+                ),
+                child: const Text('Continue'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildImportActions() {
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: _isLoading ? null : _importMusicXml,
+            icon: _isLoading
+                ? const SizedBox(
+                    height: 16,
+                    width: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.music_note_outlined),
+            label: const Text('Import MusicXML'),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: _isLoading ? null : _importJson,
+            icon: const Icon(Icons.developer_mode_outlined),
+            label: const Text('Import JSON (DEV)'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMessageCard({
+    required String title,
+    required Color color,
+    required List<String> messages,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: color.withValues(alpha: 0.4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(color: color, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 6),
+          for (final message in messages)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 3),
+              child: Text(
+                '• $message',
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 12,
+                  height: 1.35,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _importMusicXml() async {
+    setState(() {
+      _isLoading = true;
+      _errors = const [];
+      _warnings = const [];
+      _importedScore = null;
+    });
+
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowMultiple: false,
+      withData: true,
+      allowedExtensions: const ['xml', 'musicxml'],
+    );
+
+    if (!mounted) return;
+    if (result == null || result.files.isEmpty) {
+      setState(() => _isLoading = false);
+      return;
+    }
+
+    final file = result.files.single;
+    final data = file.bytes;
+    if (data == null) {
+      setState(() {
+        _isLoading = false;
+        _selectedFileName = file.name;
+        _errors = const ['Unable to read file bytes.'];
+      });
+      return;
+    }
+
+    try {
+      final xmlContent = utf8.decode(data);
+      final parsed = _xmlParser.parse(xmlContent);
+      if (!parsed.success || parsed.document == null) {
+        setState(() {
+          _selectedFileName = file.name;
+          _errors = [parsed.errorMessage ?? 'Invalid MusicXML content.'];
+          _warnings = const [];
+          _importedScore = null;
+          _isLoading = false;
+        });
+        return;
+      }
+
+      final validation = _xmlValidator.validate(parsed.document!);
+      if (!validation.isValid) {
+        setState(() {
+          _selectedFileName = file.name;
+          _errors = validation.validationErrors;
+          _warnings = validation.warnings;
+          _importedScore = null;
+          _isLoading = false;
+        });
+        return;
+      }
+
+      final score = _xmlConverter.convert(parsed.document!);
+      setState(() {
+        _selectedFileName = file.name;
+        _errors = const [];
+        _warnings = validation.warnings;
+        _importedScore = score;
+        _isLoading = false;
+      });
+    } catch (_) {
+      setState(() {
+        _selectedFileName = file.name;
+        _errors = const ['Could not import MusicXML file.'];
+        _warnings = const [];
+        _importedScore = null;
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _importJson() async {
+    setState(() {
+      _errors = const [];
+      _warnings = const [];
+      _importedScore = null;
+    });
+
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowMultiple: false,
+      withData: true,
+      allowedExtensions: const ['json'],
+    );
+
+    if (!mounted || result == null || result.files.isEmpty) return;
+    final file = result.files.single;
+    final data = file.bytes;
+
+    if (data == null) {
+      setState(() {
+        _selectedFileName = file.name;
+        _errors = const ['Unable to read JSON file.'];
+      });
+      return;
+    }
+
+    try {
+      final score = _scoreFromJson(utf8.decode(data));
+      setState(() {
+        _selectedFileName = file.name;
+        _importedScore = score;
+        _errors = const [];
+        _warnings = const ['JSON import is a temporary developer feature.'];
+      });
+    } catch (_) {
+      setState(() {
+        _selectedFileName = file.name;
+        _importedScore = null;
+        _errors = const ['Invalid score JSON format.'];
+        _warnings = const [];
+      });
+    }
+  }
+
+  Score _scoreFromJson(String content) {
+    final root = jsonDecode(content);
+    if (root is! Map) {
+      throw const FormatException('JSON root must be an object');
+    }
+    final rootMap = Map<String, dynamic>.from(root);
+
+    final partMaps = (rootMap['parts'] as List?)
+            ?.whereType<Map>()
+            .map((part) => Map<String, dynamic>.from(part))
+            .toList() ??
+        [];
+    if (partMaps.isEmpty) {
+      throw const FormatException('Score JSON must include parts');
+    }
+
+    final parts = partMaps.map((part) {
+      final measureMaps = (part['measures'] as List?)
+              ?.whereType<Map>()
+              .map((measure) => Map<String, dynamic>.from(measure))
+              .toList() ??
+          [];
+      return Part(
+        id: (part['id']?.toString().isNotEmpty ?? false)
+            ? part['id'].toString()
+            : 'P1',
+        name: part['name']?.toString() ?? 'Part 1',
+        measures: measureMaps.map(_measureFromJson).toList(),
+      );
+    }).toList();
+
+    return Score(
+      id: rootMap['id']?.toString() ?? 'imported-score',
+      title: rootMap['title']?.toString() ?? 'Imported Score',
+      composer: rootMap['composer']?.toString() ?? 'Unknown',
+      parts: parts,
+    );
+  }
+
+  Measure _measureFromJson(Map<String, dynamic> measure) {
+    final symbolMaps = (measure['symbols'] as List?)
+            ?.whereType<Map>()
+            .map((symbol) => Map<String, dynamic>.from(symbol))
+            .toList() ??
+        [];
+    return Measure(
+      number: (measure['number'] as num?)?.toInt() ?? 1,
+      symbols: symbolMaps.map(_symbolFromJson).toList(),
+    );
+  }
+
+  ScoreSymbol _symbolFromJson(Map<String, dynamic> symbol) {
+    final type = symbol['type']?.toString().toLowerCase();
+    if (type == 'rest') {
+      return Rest(
+        duration: (symbol['duration'] as num?)?.toInt() ?? 1,
+        type: symbol['restType']?.toString() ??
+            symbol['noteType']?.toString() ??
+            'quarter',
+        voice: (symbol['voice'] as num?)?.toInt(),
+        staff: (symbol['staff'] as num?)?.toInt(),
+      );
+    }
+
+    final pitch = symbol['pitch']?.toString().toUpperCase() ?? 'C4';
+    final match = RegExp(r'^([A-G])([#B]*)(\d)$').firstMatch(pitch);
+    final step = match?.group(1) ?? symbol['step']?.toString().toUpperCase() ?? 'C';
+    final accidental = match?.group(2) ?? '';
+    final alter = accidental.isEmpty
+        ? (symbol['alter'] as num?)?.toInt()
+        : accidental.replaceAll('B', 'b').split('').fold<int>(
+              0,
+              (value, c) => value + (c == '#' ? 1 : c == 'b' ? -1 : 0),
+            );
+    final octave = int.tryParse(match?.group(3) ?? '') ??
+        (symbol['octave'] as num?)?.toInt() ??
+        4;
+
+    return Note(
+      step: step,
+      octave: octave,
+      alter: alter,
+      duration: (symbol['duration'] as num?)?.toInt() ?? 1,
+      type: symbol['noteType']?.toString() ??
+          symbol['typeName']?.toString() ??
+          'quarter',
+      voice: (symbol['voice'] as num?)?.toInt(),
+      staff: (symbol['staff'] as num?)?.toInt(),
+    );
+  }
+
+  void _continueToEditor() {
+    final score = _importedScore;
+    if (score == null) return;
+
+    Navigator.pushNamed(
+      context,
+      EditorShellScreen.routeName,
+      arguments: EditorShellArgs(
+        score: score,
+        initialState: EditorState(score: score),
+      ),
+    );
+  }
+}

--- a/lib/features/collection/presentation/collection_screen.dart
+++ b/lib/features/collection/presentation/collection_screen.dart
@@ -318,6 +318,8 @@ class _CollectionScreenState extends State<CollectionScreen>
 
   @override
   Widget build(BuildContext context) {
+    final orientation = MediaQuery.of(context).orientation;
+    final isLandscape = orientation == Orientation.landscape;
     final horizontalPadding =
         ResponsiveLayout.horizontalPadding(MediaQuery.of(context).size.width);
 
@@ -335,27 +337,27 @@ class _CollectionScreenState extends State<CollectionScreen>
             colorBlendMode: BlendMode.srcIn,
           ),
         ),
-        title: const Text(
+        title: Text(
           'Note Vision',
           style: TextStyle(
             fontFamily: 'MaturaMTScriptCapitals',
-            fontSize: 22,
+            fontSize: isLandscape ? 20 : 22,
             color: AppColors.textPrimary,
             letterSpacing: 0.5,
           ),
         ),
         centerTitle: true,
         bottom: PreferredSize(
-          preferredSize: const Size.fromHeight(48),
+          preferredSize: Size.fromHeight(isLandscape ? 42 : 48),
           child: Padding(
-            padding: EdgeInsets.fromLTRB(horizontalPadding, 0, horizontalPadding, 12),
+            padding: EdgeInsets.fromLTRB(horizontalPadding, 0, horizontalPadding, isLandscape ? 8 : 12),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                const Text(
+                Text(
                   'MY COLLECTION',
                   style: TextStyle(
-                    fontSize: 11,
+                    fontSize: isLandscape ? 10 : 11,
                     fontWeight: FontWeight.w600,
                     color: AppColors.textSecondary,
                     letterSpacing: 2.0,
@@ -364,8 +366,8 @@ class _CollectionScreenState extends State<CollectionScreen>
                 if (!_isLoading && _imagePaths.isNotEmpty)
                   Text(
                     '${_imagePaths.length} items',
-                    style: const TextStyle(
-                      fontSize: 11,
+                    style: TextStyle(
+                      fontSize: isLandscape ? 10 : 11,
                       color: AppColors.textSecondary,
                       letterSpacing: 0.3,
                     ),

--- a/lib/features/collection/presentation/widgets/empty_collection.dart
+++ b/lib/features/collection/presentation/widgets/empty_collection.dart
@@ -46,12 +46,20 @@ class _EmptyCollectionState extends State<EmptyCollection>
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 40),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
+    final isLandscape =
+        MediaQuery.of(context).orientation == Orientation.landscape;
+
+    return LayoutBuilder(
+      builder: (context, constraints) => SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minHeight: constraints.maxHeight - 16),
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 40),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
             // Animated icon
             AnimatedBuilder(
               animation: _pulse,
@@ -81,14 +89,14 @@ class _EmptyCollectionState extends State<EmptyCollection>
               ),
             ),
 
-            const SizedBox(height: 32),
+            SizedBox(height: isLandscape ? 18 : 32),
 
             // Heading
-            const Text(
+            Text(
               'Your collection\nis empty',
               textAlign: TextAlign.center,
               style: TextStyle(
-                fontSize: 26,
+                fontSize: isLandscape ? 22 : 26,
                 fontWeight: FontWeight.w700,
                 color: _textPri,
                 height: 1.2,
@@ -96,7 +104,7 @@ class _EmptyCollectionState extends State<EmptyCollection>
               ),
             ),
 
-            const SizedBox(height: 12),
+            const SizedBox(height: 10),
 
             // Subtext
             const Text(
@@ -110,7 +118,7 @@ class _EmptyCollectionState extends State<EmptyCollection>
               ),
             ),
 
-            const SizedBox(height: 40),
+            SizedBox(height: isLandscape ? 20 : 40),
 
             // CTA button
             GestureDetector(
@@ -149,7 +157,7 @@ class _EmptyCollectionState extends State<EmptyCollection>
               ),
             ),
 
-            const SizedBox(height: 12),
+            const SizedBox(height: 10),
 
             // Secondary hint
             Row(
@@ -171,7 +179,10 @@ class _EmptyCollectionState extends State<EmptyCollection>
                 ),
               ],
             ),
-          ],
+                ],
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/detection_inspector/widgets/di_score_preview.dart
+++ b/lib/features/detection_inspector/widgets/di_score_preview.dart
@@ -21,10 +21,7 @@ class DiScorePreview extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          ScoreNotationViewer(
-            score: score,
-            backgroundColor: const Color(0xFF0B0E16),
-          ),
+          ScoreNotationViewer(score: score),
           const SizedBox(height: 12),
           _MonoBlock(text: debug),
         ],

--- a/lib/features/editor/domain/editor_actions.dart
+++ b/lib/features/editor/domain/editor_actions.dart
@@ -142,6 +142,41 @@ extension EditorActions on EditorState {
 
   EditorState applyRedo() => redo();
 
+  EditorState moveSelectedSymbolToMeasureOffset(int offset) {
+    if (!hasSelection || offset == 0) return this;
+
+    final partIndex = selectedPartIndex!;
+    final fromMeasureIndex = selectedMeasureIndex!;
+    final toMeasureIndex = fromMeasureIndex + offset;
+    final measures = score.parts[partIndex].measures;
+    if (toMeasureIndex < 0 || toMeasureIndex >= measures.length) return this;
+
+    final fromSymbols = List<ScoreSymbol>.from(measures[fromMeasureIndex].symbols);
+    final toSymbols = List<ScoreSymbol>.from(measures[toMeasureIndex].symbols);
+    final fromSymbolIndex = selectedSymbolIndex!;
+    if (fromSymbolIndex < 0 || fromSymbolIndex >= fromSymbols.length) return this;
+
+    final moved = fromSymbols.removeAt(fromSymbolIndex);
+    toSymbols.add(moved);
+    final toSymbolIndex = toSymbols.length - 1;
+
+    final nextScore = _replaceMeasureSymbolsBatch(
+      partIndex: partIndex,
+      updates: {
+        fromMeasureIndex: fromSymbols,
+        toMeasureIndex: toSymbols,
+      },
+    );
+
+    return applyEdit(
+      score: nextScore,
+      selectedPartIndex: partIndex,
+      selectedMeasureIndex: toMeasureIndex,
+      selectedSymbolIndex: toSymbolIndex,
+      selectedSymbol: moved,
+    );
+  }
+
   EditorState reorderSymbolWithinMeasure({
     required int measureIndex,
     required int fromSymbolIndex,
@@ -285,6 +320,40 @@ extension EditorActions on EditorState {
       parts: parts,
     );
   }
+
+  Score _replaceMeasureSymbolsBatch({
+    required int partIndex,
+    required Map<int, List<ScoreSymbol>> updates,
+  }) {
+    final parts = List<Part>.from(score.parts);
+    final measures = List<Measure>.from(parts[partIndex].measures);
+
+    for (final entry in updates.entries) {
+      final measureIndex = entry.key;
+      final currentMeasure = measures[measureIndex];
+      measures[measureIndex] = Measure(
+        number: currentMeasure.number,
+        clef: currentMeasure.clef,
+        timeSignature: currentMeasure.timeSignature,
+        keySignature: currentMeasure.keySignature,
+        symbols: entry.value,
+      );
+    }
+
+    final currentPart = parts[partIndex];
+    parts[partIndex] = Part(
+      id: currentPart.id,
+      name: currentPart.name,
+      measures: measures,
+    );
+
+    return Score(
+      id: score.id,
+      title: score.title,
+      composer: score.composer,
+      parts: parts,
+    );
+  }
 }
 
 Note _moveNoteByScaleStep(Note note, int steps) {
@@ -307,7 +376,7 @@ Note _moveNoteByScaleStep(Note note, int steps) {
 
   return Note(
     step: stepsByName[nextIndex],
-    octave: nextOctave.clamp(0, 9),
+    octave: nextOctave.clamp(1, 7),
     alter: note.alter,
     duration: note.duration,
     type: note.type,

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -5,6 +5,7 @@ import 'package:note_vision/core/models/score.dart';
 import 'package:note_vision/core/theme/app_theme.dart';
 import 'package:note_vision/core/theme/responsive_layout.dart';
 import 'package:note_vision/core/widgets/score_notation_viewer.dart';
+import 'package:note_vision/features/editor/domain/editor_actions.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
 
 class EditorShellArgs {

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -97,6 +97,10 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
     final hasSelection = _editorState.hasSelection;
     final hasMeasureContext =
         _editorState.selectedPartIndex != null && _editorState.selectedMeasureIndex != null;
+    final selectedMeasureIndex = _editorState.selectedMeasureIndex ?? 0;
+    final measureCount = _editorState.score.parts.isEmpty
+        ? 0
+        : _editorState.score.parts.first.measures.length;
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -163,6 +167,26 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                   measure: _editorState.selectedMeasureIndex == null
                       ? '—'
                       : (_editorState.selectedMeasureIndex! + 1).toString(),
+                  onPrevMeasure: selectedMeasureIndex > 0
+                      ? () => _updateState(
+                            (s) => s.copyWith(
+                              selectedPartIndex: 0,
+                              selectedMeasureIndex: selectedMeasureIndex - 1,
+                              selectedSymbolIndex: null,
+                              selectedSymbol: null,
+                            ),
+                          )
+                      : null,
+                  onNextMeasure: selectedMeasureIndex < measureCount - 1
+                      ? () => _updateState(
+                            (s) => s.copyWith(
+                              selectedPartIndex: 0,
+                              selectedMeasureIndex: selectedMeasureIndex + 1,
+                              selectedSymbolIndex: null,
+                              selectedSymbol: null,
+                            ),
+                          )
+                      : null,
                 ),
                 _EditorActionBar(
                   horizontalPadding: horizontalPadding,
@@ -179,6 +203,10 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                   onInsertNote: () => _updateState((s) => s.insertNoteAfterSelection()),
                   onInsertRest: () => _updateState((s) => s.insertRestAfterSelection()),
                   onDelete: () => _updateState((s) => s.deleteSelectedSymbol()),
+                  onMoveToPrevMeasure: () =>
+                      _updateState((s) => s.moveSelectedSymbolToMeasureOffset(-1)),
+                  onMoveToNextMeasure: () =>
+                      _updateState((s) => s.moveSelectedSymbolToMeasureOffset(1)),
                   onUndo: () => _updateState((s) => s.applyUndo()),
                   onRedo: () => _updateState((s) => s.applyRedo()),
                 ),
@@ -278,6 +306,8 @@ class _StatusStrip extends StatelessWidget {
     required this.pitch,
     required this.durationType,
     required this.measure,
+    required this.onPrevMeasure,
+    required this.onNextMeasure,
   });
 
   final double horizontalPadding;
@@ -285,6 +315,8 @@ class _StatusStrip extends StatelessWidget {
   final String pitch;
   final String durationType;
   final String measure;
+  final VoidCallback? onPrevMeasure;
+  final VoidCallback? onNextMeasure;
 
   @override
   Widget build(BuildContext context) {
@@ -304,8 +336,36 @@ class _StatusStrip extends StatelessWidget {
           _StatusItem(label: 'Pitch', value: pitch),
           _StatusItem(label: 'Duration', value: durationType),
           _StatusItem(label: 'Measure', value: measure),
+          _StatusNavButton(
+            icon: Icons.chevron_left_rounded,
+            onPressed: onPrevMeasure,
+          ),
+          _StatusNavButton(
+            icon: Icons.chevron_right_rounded,
+            onPressed: onNextMeasure,
+          ),
         ],
       ),
+    );
+  }
+}
+
+class _StatusNavButton extends StatelessWidget {
+  const _StatusNavButton({required this.icon, required this.onPressed});
+
+  final IconData icon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton(
+      onPressed: onPressed,
+      style: OutlinedButton.styleFrom(
+        side: const BorderSide(color: AppColors.border),
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+        minimumSize: const Size(32, 32),
+      ),
+      child: Icon(icon, size: 18),
     );
   }
 }
@@ -363,6 +423,8 @@ class _EditorActionBar extends StatelessWidget {
     required this.onInsertNote,
     required this.onInsertRest,
     required this.onDelete,
+    required this.onMoveToPrevMeasure,
+    required this.onMoveToNextMeasure,
     required this.onUndo,
     required this.onRedo,
   });
@@ -381,6 +443,8 @@ class _EditorActionBar extends StatelessWidget {
   final VoidCallback onInsertNote;
   final VoidCallback onInsertRest;
   final VoidCallback onDelete;
+  final VoidCallback onMoveToPrevMeasure;
+  final VoidCallback onMoveToNextMeasure;
   final VoidCallback onUndo;
   final VoidCallback onRedo;
 
@@ -415,6 +479,14 @@ class _EditorActionBar extends StatelessWidget {
               _ActionButton(label: 'Insert Note', onPressed: hasMeasureContext ? onInsertNote : null),
               _ActionButton(label: 'Insert Rest', onPressed: hasMeasureContext ? onInsertRest : null),
               _ActionButton(label: 'Delete', onPressed: hasSelection ? onDelete : null),
+              _ActionButton(
+                label: 'To Prev Measure',
+                onPressed: hasSelection ? onMoveToPrevMeasure : null,
+              ),
+              _ActionButton(
+                label: 'To Next Measure',
+                onPressed: hasSelection ? onMoveToNextMeasure : null,
+              ),
               _ActionButton(label: 'Undo', onPressed: canUndo ? onUndo : null),
               _ActionButton(label: 'Redo', onPressed: canRedo ? onRedo : null),
             ],

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -5,7 +5,6 @@ import 'package:note_vision/core/models/score.dart';
 import 'package:note_vision/core/theme/app_theme.dart';
 import 'package:note_vision/core/theme/responsive_layout.dart';
 import 'package:note_vision/core/widgets/score_notation_viewer.dart';
-import 'package:note_vision/features/editor/domain/editor_actions.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
 
 class EditorShellArgs {
@@ -50,9 +49,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
           state.selectedMeasureIndex == measureIndex &&
           state.selectedSymbolIndex == symbolIndex;
 
-      if (isSameSelection) {
-        return _clearSymbolSelection(state);
-      }
+      if (isSameSelection) return _clearSymbolSelection(state);
 
       final parts = state.score.parts;
       if (parts.isEmpty || measureIndex < 0 || measureIndex >= parts.first.measures.length) {
@@ -98,52 +95,56 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
     final selected = _editorState.selectedSymbol;
     final hasSelection = _editorState.hasSelection;
     final hasMeasureContext =
-        _editorState.selectedPartIndex != null &&
-        _editorState.selectedMeasureIndex != null;
+        _editorState.selectedPartIndex != null && _editorState.selectedMeasureIndex != null;
 
     return Scaffold(
       backgroundColor: AppColors.background,
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final horizontalPadding =
-                ResponsiveLayout.horizontalPadding(constraints.maxWidth);
-
+            final horizontalPadding = ResponsiveLayout.horizontalPadding(constraints.maxWidth);
             return Column(
               children: [
                 _EditorHeader(
-                  title: _editorState.score.title.isEmpty
-                      ? 'Untitled Score'
-                      : _editorState.score.title,
+                  title: _editorState.score.title.isEmpty ? 'Untitled Score' : _editorState.score.title,
                   hasUnsavedChanges: _editorState.hasUnsavedChanges,
                   horizontalPadding: horizontalPadding,
+                  onBack: () => Navigator.of(context).maybePop(),
                 ),
                 Expanded(
                   child: Padding(
                     padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
-                    child: SingleChildScrollView(
-                      child: Padding(
-                        padding: const EdgeInsets.only(bottom: 12),
-                        child: ScoreNotationViewer(
-                          score: _editorState.score,
-                          selectedMeasureIndex: _editorState.selectedMeasureIndex,
-                          selectedSymbolIndex: _editorState.selectedSymbolIndex,
-                          onSymbolTap: (target) {
-                            if (target == null) {
-                              _updateState((state) => _clearSymbolSelection(state));
-                              return;
-                            }
-                            _onNotationSymbolTap(target.measureIndex, target.symbolIndex);
-                          },
-                          onSymbolReorder: (event) {
-                            _updateState(
-                              (state) => state.reorderSymbolWithinMeasure(
-                                measureIndex: event.measureIndex,
-                                fromSymbolIndex: event.fromSymbolIndex,
-                                toSymbolIndex: event.toSymbolIndex,
-                              ),
-                            );
-                          },
+                    child: Container(
+                      margin: const EdgeInsets.only(bottom: 12),
+                      decoration: BoxDecoration(
+                        color: AppColors.surface,
+                        borderRadius: BorderRadius.circular(14),
+                        border: Border.all(color: AppColors.border),
+                      ),
+                      child: SingleChildScrollView(
+                        child: Padding(
+                          padding: const EdgeInsets.all(8),
+                          child: ScoreNotationViewer(
+                            score: _editorState.score,
+                            selectedMeasureIndex: _editorState.selectedMeasureIndex,
+                            selectedSymbolIndex: _editorState.selectedSymbolIndex,
+                            onSymbolTap: (target) {
+                              if (target == null) {
+                                _updateState((state) => _clearSymbolSelection(state));
+                                return;
+                              }
+                              _onNotationSymbolTap(target.measureIndex, target.symbolIndex);
+                            },
+                            onSymbolReorder: (event) {
+                              _updateState(
+                                (state) => state.reorderSymbolWithinMeasure(
+                                  measureIndex: event.measureIndex,
+                                  fromSymbolIndex: event.fromSymbolIndex,
+                                  toSymbolIndex: event.toSymbolIndex,
+                                ),
+                              );
+                            },
+                          ),
                         ),
                       ),
                     ),
@@ -151,11 +152,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                 ),
                 _StatusStrip(
                   horizontalPadding: horizontalPadding,
-                  symbolType: selected == null
-                      ? 'None'
-                      : selected is Note
-                          ? 'Note'
-                          : 'Rest',
+                  symbolType: selected == null ? 'None' : selected is Note ? 'Note' : 'Rest',
                   pitch: selected is Note ? selected.pitch : '—',
                   durationType: selected == null
                       ? '—'
@@ -173,21 +170,13 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                   canUndo: _editorState.canUndo,
                   canRedo: _editorState.canRedo,
                   onMoveUp: () => _updateState((s) => s.moveSelectedSymbolUp()),
-                  onMoveDown: () =>
-                      _updateState((s) => s.moveSelectedSymbolDown()),
-                  onWhole: () =>
-                      _updateState((s) => s.setSelectedDuration(wholeDuration)),
-                  onHalf: () =>
-                      _updateState((s) => s.setSelectedDuration(halfDuration)),
-                  onQuarter: () => _updateState(
-                    (s) => s.setSelectedDuration(quarterDuration),
-                  ),
-                  onEighth: () =>
-                      _updateState((s) => s.setSelectedDuration(eighthDuration)),
-                  onInsertNote: () =>
-                      _updateState((s) => s.insertNoteAfterSelection()),
-                  onInsertRest: () =>
-                      _updateState((s) => s.insertRestAfterSelection()),
+                  onMoveDown: () => _updateState((s) => s.moveSelectedSymbolDown()),
+                  onWhole: () => _updateState((s) => s.setSelectedDuration(wholeDuration)),
+                  onHalf: () => _updateState((s) => s.setSelectedDuration(halfDuration)),
+                  onQuarter: () => _updateState((s) => s.setSelectedDuration(quarterDuration)),
+                  onEighth: () => _updateState((s) => s.setSelectedDuration(eighthDuration)),
+                  onInsertNote: () => _updateState((s) => s.insertNoteAfterSelection()),
+                  onInsertRest: () => _updateState((s) => s.insertRestAfterSelection()),
                   onDelete: () => _updateState((s) => s.deleteSelectedSymbol()),
                   onUndo: () => _updateState((s) => s.applyUndo()),
                   onRedo: () => _updateState((s) => s.applyRedo()),
@@ -206,36 +195,76 @@ class _EditorHeader extends StatelessWidget {
     required this.title,
     required this.hasUnsavedChanges,
     required this.horizontalPadding,
+    required this.onBack,
   });
 
   final String title;
   final bool hasUnsavedChanges;
   final double horizontalPadding;
+  final VoidCallback onBack;
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.fromLTRB(horizontalPadding, 12, horizontalPadding, 8),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              hasUnsavedChanges ? '$title *' : title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                color: AppColors.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w600,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: AppColors.border),
+        ),
+        child: Row(
+          children: [
+            IconButton(
+              onPressed: onBack,
+              icon: const Icon(Icons.arrow_back_ios_new, size: 16),
+              color: AppColors.textPrimary,
+              tooltip: 'Back',
+            ),
+            const SizedBox(width: 4),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    hasUnsavedChanges ? '$title *' : title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  const Text(
+                    'Editor Workspace',
+                    style: TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
               ),
             ),
-          ),
-          FilledButton.icon(
-            onPressed: () {},
-            icon: const Icon(Icons.save_outlined),
-            label: const Text('Save'),
-          ),
-        ],
+            FilledButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.save_outlined, size: 18),
+              label: const Text('Save'),
+            ),
+            const SizedBox(width: 8),
+            OutlinedButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.ios_share_outlined, size: 16),
+              label: const Text('Export'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.textPrimary,
+                side: const BorderSide(color: AppColors.border),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -260,13 +289,15 @@ class _StatusStrip extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       margin: EdgeInsets.fromLTRB(horizontalPadding, 8, horizontalPadding, 8),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
         color: AppColors.surface,
-        borderRadius: BorderRadius.circular(10),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
       ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 8,
         children: [
           _StatusItem(label: 'Type', value: symbolType),
           _StatusItem(label: 'Pitch', value: pitch),
@@ -286,22 +317,31 @@ class _StatusItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          label,
-          style: const TextStyle(fontSize: 10, color: AppColors.textSecondary),
-        ),
-        Text(
-          value,
-          style: const TextStyle(
-            color: AppColors.textPrimary,
-            fontSize: 12,
-            fontWeight: FontWeight.w600,
+    return Container(
+      constraints: const BoxConstraints(minWidth: 82),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceAlt,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(fontSize: 10, color: AppColors.textSecondary),
           ),
-        ),
-      ],
+          Text(
+            value,
+            style: const TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -347,47 +387,38 @@ class _EditorActionBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       color: AppColors.surfaceAlt,
-      padding: EdgeInsets.fromLTRB(
-        horizontalPadding / 2,
-        8,
-        horizontalPadding / 2,
-        16,
-      ),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: Row(
-          children: [
-            _ActionButton(
-              label: 'Move Up',
-              onPressed: hasSelection ? onMoveUp : null,
+      padding: EdgeInsets.fromLTRB(horizontalPadding, 10, horizontalPadding, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'TOOLS',
+            style: TextStyle(
+              fontSize: 11,
+              color: AppColors.textSecondary,
+              letterSpacing: 1.1,
+              fontWeight: FontWeight.w600,
             ),
-            _ActionButton(
-              label: 'Move Down',
-              onPressed: hasSelection ? onMoveDown : null,
-            ),
-            _ActionButton(label: 'W', onPressed: hasSelection ? onWhole : null),
-            _ActionButton(label: 'H', onPressed: hasSelection ? onHalf : null),
-            _ActionButton(
-              label: 'Q',
-              onPressed: hasSelection ? onQuarter : null,
-            ),
-            _ActionButton(label: 'E', onPressed: hasSelection ? onEighth : null),
-            _ActionButton(
-              label: 'Insert Note',
-              onPressed: hasMeasureContext ? onInsertNote : null,
-            ),
-            _ActionButton(
-              label: 'Insert Rest',
-              onPressed: hasMeasureContext ? onInsertRest : null,
-            ),
-            _ActionButton(
-              label: 'Delete',
-              onPressed: hasSelection ? onDelete : null,
-            ),
-            _ActionButton(label: 'Undo', onPressed: canUndo ? onUndo : null),
-            _ActionButton(label: 'Redo', onPressed: canRedo ? onRedo : null),
-          ],
-        ),
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _ActionButton(label: 'Move Up', onPressed: hasSelection ? onMoveUp : null),
+              _ActionButton(label: 'Move Down', onPressed: hasSelection ? onMoveDown : null),
+              _ActionButton(label: 'Whole', onPressed: hasSelection ? onWhole : null),
+              _ActionButton(label: 'Half', onPressed: hasSelection ? onHalf : null),
+              _ActionButton(label: 'Quarter', onPressed: hasSelection ? onQuarter : null),
+              _ActionButton(label: 'Eighth', onPressed: hasSelection ? onEighth : null),
+              _ActionButton(label: 'Insert Note', onPressed: hasMeasureContext ? onInsertNote : null),
+              _ActionButton(label: 'Insert Rest', onPressed: hasMeasureContext ? onInsertRest : null),
+              _ActionButton(label: 'Delete', onPressed: hasSelection ? onDelete : null),
+              _ActionButton(label: 'Undo', onPressed: canUndo ? onUndo : null),
+              _ActionButton(label: 'Redo', onPressed: canRedo ? onRedo : null),
+            ],
+          ),
+        ],
       ),
     );
   }
@@ -401,16 +432,18 @@ class _ActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 4),
-      child: OutlinedButton(
-        onPressed: onPressed,
-        style: OutlinedButton.styleFrom(
-          foregroundColor: AppColors.textPrimary,
-          side: const BorderSide(color: AppColors.border),
+    final enabled = onPressed != null;
+    return OutlinedButton(
+      onPressed: onPressed,
+      style: OutlinedButton.styleFrom(
+        backgroundColor: enabled ? AppColors.surface : AppColors.surfaceAlt,
+        foregroundColor: enabled ? AppColors.textPrimary : AppColors.textSecondary,
+        side: BorderSide(
+          color: enabled ? AppColors.accent.withValues(alpha: 0.6) : AppColors.border,
         ),
-        child: Text(label),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       ),
+      child: Text(label),
     );
   }
 }

--- a/lib/features/landing/presentation/landing_screen.dart
+++ b/lib/features/landing/presentation/landing_screen.dart
@@ -59,7 +59,9 @@ class _LandingScreenState extends State<LandingScreen>
   @override
   Widget build(BuildContext context) {
     final size = MediaQuery.of(context).size;
-    final horizontalPadding = ResponsiveLayout.horizontalPadding(size.width) * 1.5;
+    final orientation = MediaQuery.of(context).orientation;
+    final isLandscape = orientation == Orientation.landscape;
+    final horizontalPadding = ResponsiveLayout.horizontalPadding(size.width) * (isLandscape ? 1.0 : 1.5);
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -86,82 +88,132 @@ class _LandingScreenState extends State<LandingScreen>
                 position: _slideUp,
                 child: Padding(
                   padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
-                  child: Column(
-                    children: [
-                      const Spacer(flex: 3),
-
-                      // ── Title ──────────────────────────────────────────
-                      Text(
-                        'Note Vision',
-                        style: TextStyle(
-                          fontFamily: 'MaturaMTScriptCapitals',
-                          fontSize: 50,
-                          color: AppColors.textPrimary,
-                          letterSpacing: 1.5,
-                        ),
-                      ),
-
-                      const Spacer(flex: 1),
-
-                      // ── Logo with glow ─────────────────────────────────
-                      Container(
-                        width: 160,
-                        height: 160,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                        ),
-                        child: Image.asset(
-                          'assets/images/notevision.png',
-                          width: 160,
-                          height: 160,
-                          colorBlendMode: BlendMode.srcIn,
-                        ),
-                      ),
-
-                      const Spacer(flex: 1),
-
-                      // ── Tagline ────────────────────────────────────────
-                      Text(
-                        'Read music. Understand it.',
-                        style: TextStyle(
-                          fontSize: 13,
-                          color: AppColors.textSecondary,
-                          letterSpacing: 2.0,
-                          fontWeight: FontWeight.w300,
-                        ),
-                      ),
-
-                      const Spacer(flex: 3),
-
-                      // ── Get Started (primary) ──────────────────────────
-                      _PrimaryButton(
-                        label: 'Get Started',
-                        onPressed: () => Navigator.push(
-                          context,
-                          _fadeRoute(const CollectionScreen()),
-                        ),
-                      ),
-
-                      const SizedBox(height: 14),
-
-                      // ── Dev's Workbench (ghost) ────────────────────────
-                      _GhostButton(
-                        label: "Dev's Workbench",
-                        onPressed: () => Navigator.push(
-                          context,
-                          _fadeRoute(const MusicXmlInspectorScreen()),
-                        ),
-                      ),
-
-                      const Spacer(flex: 2),
-                      const SizedBox(height: 16),
-                    ],
-                  ),
+                  child: isLandscape
+                      ? _buildLandscapeLayout(context)
+                      : _buildPortraitLayout(context),
                 ),
               ),
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildPortraitLayout(BuildContext context) {
+    return Column(
+      children: [
+        const Spacer(flex: 3),
+        Text(
+          'Note Vision',
+          style: TextStyle(
+            fontFamily: 'MaturaMTScriptCapitals',
+            fontSize: 50,
+            color: AppColors.textPrimary,
+            letterSpacing: 1.5,
+          ),
+        ),
+        const Spacer(flex: 1),
+        _buildLogo(size: 160),
+        const Spacer(flex: 1),
+        _buildTagline(),
+        const Spacer(flex: 3),
+        _buildPrimaryAction(context),
+        const SizedBox(height: 14),
+        _buildWorkbenchAction(context),
+        const Spacer(flex: 2),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+
+  Widget _buildLandscapeLayout(BuildContext context) {
+    return Center(
+      child: SingleChildScrollView(
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildLogo(size: 130),
+                  const SizedBox(height: 12),
+                  _buildTagline(),
+                ],
+              ),
+            ),
+            const SizedBox(width: 28),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'Note Vision',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontFamily: 'MaturaMTScriptCapitals',
+                      fontSize: 42,
+                      color: AppColors.textPrimary,
+                      letterSpacing: 1.2,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  _buildPrimaryAction(context),
+                  const SizedBox(height: 14),
+                  _buildWorkbenchAction(context),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLogo({required double size}) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: const BoxDecoration(shape: BoxShape.circle),
+      child: Image.asset(
+        'assets/images/notevision.png',
+        width: size,
+        height: size,
+        colorBlendMode: BlendMode.srcIn,
+      ),
+    );
+  }
+
+  Widget _buildTagline() {
+    return Text(
+      'Read music. Understand it.',
+      textAlign: TextAlign.center,
+      style: TextStyle(
+        fontSize: 13,
+        color: AppColors.textSecondary,
+        letterSpacing: 2.0,
+        fontWeight: FontWeight.w300,
+      ),
+    );
+  }
+
+  Widget _buildPrimaryAction(BuildContext context) {
+    return _PrimaryButton(
+      label: 'Get Started',
+      onPressed: () => Navigator.push(
+        context,
+        _fadeRoute(const CollectionScreen()),
+      ),
+    );
+  }
+
+  Widget _buildWorkbenchAction(BuildContext context) {
+    return _GhostButton(
+      label: "Dev's Workbench",
+      onPressed: () => Navigator.push(
+        context,
+        _fadeRoute(const MusicXmlInspectorScreen()),
       ),
     );
   }

--- a/lib/features/musicxml_inspector/music_inspector_screen.dart
+++ b/lib/features/musicxml_inspector/music_inspector_screen.dart
@@ -90,9 +90,12 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final isLandscape = constraints.maxWidth > constraints.maxHeight;
+            final content = Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
             // ── Import button ─────────────────────────────────────────────
             ElevatedButton(
               onPressed: isLoading ? null : _onImportPressed,
@@ -207,8 +210,21 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
                   : null,
             ),
 
-            const SizedBox(height: 32),
-          ],
+                const SizedBox(height: 32),
+              ],
+            );
+
+            if (!isLandscape) {
+              return content;
+            }
+
+            return Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 920),
+                child: content,
+              ),
+            );
+          },
         ),
       ),
     );

--- a/lib/features/musicxml_inspector/music_inspector_screen.dart
+++ b/lib/features/musicxml_inspector/music_inspector_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../core/theme/app_theme.dart';
 import '../../core/widgets/inspector_shared_widgets.dart';
 import '../../core/widgets/score_notation_viewer.dart';
 import '../detection_inspector/detection_inspector_screen.dart';
@@ -55,9 +56,9 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
     final isLoading = _controller.isLoading;
 
     return Scaffold(
-      backgroundColor: const Color(0xFFF5F5F5),
+      backgroundColor: AppColors.background,
       appBar: AppBar(
-        backgroundColor: const Color(0xFFF5F5F5),
+        backgroundColor: AppColors.background,
         elevation: 0,
         centerTitle: true,
         title: const Text(
@@ -65,7 +66,7 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
           style: TextStyle(
             fontSize: 14,
             fontWeight: FontWeight.w600,
-            color: Color(0xFF111111),
+            color: AppColors.textPrimary,
           ),
         ),
         actions: [
@@ -73,7 +74,7 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
             margin: const EdgeInsets.only(right: 16, top: 10, bottom: 10),
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
             decoration: BoxDecoration(
-              color: const Color(0xFFE8F0FE),
+              color: AppColors.surface,
               borderRadius: BorderRadius.circular(4),
             ),
             child: const Text(
@@ -81,7 +82,7 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
               style: TextStyle(
                 fontSize: 10,
                 fontWeight: FontWeight.w600,
-                color: Color(0xFF1A56DB),
+                color: AppColors.accent,
               ),
             ),
           ),
@@ -96,10 +97,9 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
             ElevatedButton(
               onPressed: isLoading ? null : _onImportPressed,
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF185FA5),
-                foregroundColor: Colors.white,
-                disabledBackgroundColor:
-                    const Color(0xFF185FA5).withValues(alpha: 0.5),
+                backgroundColor: AppColors.surface,
+                foregroundColor: AppColors.textPrimary,
+                disabledBackgroundColor: AppColors.border,
                 padding: const EdgeInsets.symmetric(vertical: 14),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10),
@@ -133,8 +133,8 @@ class _MusicXmlInspectorScreenState extends State<MusicXmlInspectorScreen> {
                 style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
               ),
               style: OutlinedButton.styleFrom(
-                foregroundColor: const Color(0xFF185FA5),
-                side: const BorderSide(color: Color(0xFF185FA5), width: 1.5),
+                foregroundColor: AppColors.accent,
+                side: const BorderSide(color: AppColors.accent, width: 1.5),
                 padding: const EdgeInsets.symmetric(vertical: 14),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10),

--- a/lib/features/scan/presentation/scan_screen.dart
+++ b/lib/features/scan/presentation/scan_screen.dart
@@ -110,9 +110,10 @@ class _ScanScreenState extends State<ScanScreen> {
             Padding(
               padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
               child: ScanActions(
-          onRedo: () => Navigator.pop(context),
-          onImport: _importFromFile,
-          onContinue: () {
+                onRedo: () => Navigator.pop(context),
+                onImport: _importFromFile,
+                canContinue: vm.result?.hasDetections ?? false,
+                onContinue: () {
             final mappedScore = vm.mappingResult?.score ??
                 const Score(
                   id: 'scan-score',

--- a/lib/features/scan/presentation/scan_screen.dart
+++ b/lib/features/scan/presentation/scan_screen.dart
@@ -104,39 +104,60 @@ class _ScanScreenState extends State<ScanScreen> {
     return LayoutBuilder(
       builder: (context, constraints) {
         final horizontalPadding = ResponsiveLayout.horizontalPadding(constraints.maxWidth);
-        return Column(
-          children: [
-            Expanded(child: ScanImageView(result: vm.result!)),
-            Padding(
-              padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
-              child: ScanActions(
-                onRedo: () => Navigator.pop(context),
-                onImport: _importFromFile,
-                canContinue: vm.result?.hasDetections ?? false,
-                onContinue: () {
-            final mappedScore = vm.mappingResult?.score ??
-                const Score(
-                  id: 'scan-score',
-                  title: 'Scanned Score',
-                  composer: 'Unknown',
-                  parts: [
-                    Part(
-                      id: 'P1',
-                      name: 'Part 1',
-                      measures: [Measure(number: 1, symbols: [])],
-                    ),
-                  ],
-                );
+        final isLandscape = constraints.maxWidth > constraints.maxHeight;
 
-            Navigator.pushNamed(
-              context,
-              EditorShellScreen.routeName,
-              arguments: EditorShellArgs(
-                score: mappedScore,
-                initialState: EditorState(score: mappedScore),
-              ),
-            );
-          },
+        final actions = Padding(
+          padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+          child: ScanActions(
+            onRedo: () => Navigator.pop(context),
+            onImport: _importFromFile,
+            canContinue: vm.result?.hasDetections ?? false,
+            onContinue: () {
+              final mappedScore = vm.mappingResult?.score ??
+                  const Score(
+                    id: 'scan-score',
+                    title: 'Scanned Score',
+                    composer: 'Unknown',
+                    parts: [
+                      Part(
+                        id: 'P1',
+                        name: 'Part 1',
+                        measures: [Measure(number: 1, symbols: [])],
+                      ),
+                    ],
+                  );
+
+              Navigator.pushNamed(
+                context,
+                EditorShellScreen.routeName,
+                arguments: EditorShellArgs(
+                  score: mappedScore,
+                  initialState: EditorState(score: mappedScore),
+                ),
+              );
+            },
+          ),
+        );
+
+        if (!isLandscape) {
+          return Column(
+            children: [
+              Expanded(child: ScanImageView(result: vm.result!)),
+              actions,
+            ],
+          );
+        }
+
+        return Row(
+          children: [
+            Expanded(flex: 3, child: ScanImageView(result: vm.result!)),
+            Expanded(
+              flex: 2,
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 520),
+                  child: actions,
+                ),
               ),
             ),
           ],

--- a/lib/features/scan/presentation/scan_screen.dart
+++ b/lib/features/scan/presentation/scan_screen.dart
@@ -1,20 +1,13 @@
 import 'dart:typed_data';
-import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:provider/provider.dart';
-import 'package:note_vision/core/models/note.dart';
 import 'package:note_vision/core/models/measure.dart';
 import 'package:note_vision/core/models/part.dart';
-import 'package:note_vision/core/models/rest.dart';
 import 'package:note_vision/core/models/score.dart';
-import 'package:note_vision/core/models/score_symbol.dart';
 import 'package:note_vision/core/theme/app_theme.dart';
 import 'package:note_vision/core/theme/responsive_layout.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
 import 'package:note_vision/features/editor/presentation/editor_shell_screen.dart';
-import 'package:note_vision/features/musicXML/musicxml_parser_service.dart';
-import 'package:note_vision/features/musicXML/musicxml_score_converter.dart';
 import 'package:note_vision/features/detection/data/tflite_symbol_detector.dart';
 import 'package:note_vision/features/preprocessing/data/basic_image_preprocessor.dart';
 import 'package:note_vision/features/scan/presentation/scan_viewmodel.dart';
@@ -32,9 +25,6 @@ class ScanScreen extends StatefulWidget {
 }
 
 class _ScanScreenState extends State<ScanScreen> {
-  static const _xmlParser = MusicXmlParserService();
-  static const _xmlConverter = MusicXmlScoreConverter();
-
   @override
   void initState() {
     super.initState();
@@ -155,147 +145,6 @@ class _ScanScreenState extends State<ScanScreen> {
           ],
         );
       },
-    );
-  }
-
-  Future<void> _importFromFile() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowMultiple: false,
-      withData: true,
-      allowedExtensions: const ['json', 'xml', 'musicxml'],
-    );
-
-    if (!mounted || result == null || result.files.isEmpty) return;
-    final file = result.files.single;
-    final fileName = file.name;
-    final ext = fileName.split('.').last.toLowerCase();
-    final data = file.bytes;
-    if (data == null) {
-      _showImportError('Unable to read "$fileName".');
-      return;
-    }
-
-    try {
-      final importedScore = switch (ext) {
-        'json' => _scoreFromJson(utf8.decode(data)),
-        'xml' || 'musicxml' => _scoreFromMusicXml(utf8.decode(data)),
-        _ => throw const FormatException('Unsupported import type.'),
-      };
-      if (!mounted) return;
-      Navigator.pushNamed(
-        context,
-        EditorShellScreen.routeName,
-        arguments: EditorShellArgs(
-          score: importedScore,
-          initialState: EditorState(score: importedScore),
-        ),
-      );
-    } catch (_) {
-      _showImportError(
-        'Could not import "$fileName". Use a valid MusicXML or score JSON file.',
-      );
-    }
-  }
-
-  Score _scoreFromMusicXml(String content) {
-    final parsed = _xmlParser.parse(content);
-    if (!parsed.success || parsed.document == null) {
-      throw const FormatException('Invalid MusicXML');
-    }
-    return _xmlConverter.convert(parsed.document!);
-  }
-
-  Score _scoreFromJson(String content) {
-    final root = jsonDecode(content);
-    if (root is! Map) {
-      throw const FormatException('JSON root must be an object');
-    }
-    final rootMap = Map<String, dynamic>.from(root);
-
-    final partMaps = (rootMap['parts'] as List?)
-            ?.whereType<Map>()
-            .map((part) => Map<String, dynamic>.from(part))
-            .toList() ??
-        [];
-    if (partMaps.isEmpty) {
-      throw const FormatException('Score JSON must include parts');
-    }
-
-    final parts = partMaps.map((part) {
-      final measureMaps = (part['measures'] as List?)
-              ?.whereType<Map>()
-              .map((measure) => Map<String, dynamic>.from(measure))
-              .toList() ??
-          [];
-      return Part(
-        id: (part['id']?.toString().isNotEmpty ?? false) ? part['id'].toString() : 'P1',
-        name: part['name']?.toString() ?? 'Part 1',
-        measures: measureMaps.map(_measureFromJson).toList(),
-      );
-    }).toList();
-
-    return Score(
-      id: rootMap['id']?.toString() ?? 'imported-score',
-      title: rootMap['title']?.toString() ?? 'Imported Score',
-      composer: rootMap['composer']?.toString() ?? 'Unknown',
-      parts: parts,
-    );
-  }
-
-  Measure _measureFromJson(Map<String, dynamic> measure) {
-    final symbolMaps = (measure['symbols'] as List?)
-            ?.whereType<Map>()
-            .map((symbol) => Map<String, dynamic>.from(symbol))
-            .toList() ??
-        [];
-    return Measure(
-      number: (measure['number'] as num?)?.toInt() ?? 1,
-      symbols: symbolMaps.map(_symbolFromJson).toList(),
-    );
-  }
-
-  ScoreSymbol _symbolFromJson(Map<String, dynamic> symbol) {
-    final type = symbol['type']?.toString().toLowerCase();
-    if (type == 'rest') {
-      return Rest(
-        duration: (symbol['duration'] as num?)?.toInt() ?? 1,
-        type: symbol['restType']?.toString() ?? symbol['noteType']?.toString() ?? 'quarter',
-        voice: (symbol['voice'] as num?)?.toInt(),
-        staff: (symbol['staff'] as num?)?.toInt(),
-      );
-    }
-
-    final pitch = symbol['pitch']?.toString().toUpperCase() ?? 'C4';
-    final match = RegExp(r'^([A-G])([#B]*)(\d)$').firstMatch(pitch);
-    final step = match?.group(1) ?? symbol['step']?.toString().toUpperCase() ?? 'C';
-    final accidental = match?.group(2) ?? '';
-    final alter = accidental.isEmpty
-        ? (symbol['alter'] as num?)?.toInt()
-        : accidental.replaceAll('B', 'b').split('').fold<int>(
-            0,
-            (value, c) => value + (c == '#' ? 1 : c == 'b' ? -1 : 0),
-          );
-    final octave = int.tryParse(match?.group(3) ?? '') ?? (symbol['octave'] as num?)?.toInt() ?? 4;
-
-    return Note(
-      step: step,
-      octave: octave,
-      alter: alter,
-      duration: (symbol['duration'] as num?)?.toInt() ?? 1,
-      type: symbol['noteType']?.toString() ?? symbol['typeName']?.toString() ?? 'quarter',
-      voice: (symbol['voice'] as num?)?.toInt(),
-      staff: (symbol['staff'] as num?)?.toInt(),
-    );
-  }
-
-  void _showImportError(String message) {
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(message),
-        behavior: SnackBarBehavior.floating,
-      ),
     );
   }
 

--- a/lib/features/scan/presentation/scan_screen.dart
+++ b/lib/features/scan/presentation/scan_screen.dart
@@ -1,11 +1,20 @@
 import 'dart:typed_data';
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:provider/provider.dart';
+import 'package:note_vision/core/models/note.dart';
+import 'package:note_vision/core/models/measure.dart';
+import 'package:note_vision/core/models/part.dart';
+import 'package:note_vision/core/models/rest.dart';
 import 'package:note_vision/core/models/score.dart';
+import 'package:note_vision/core/models/score_symbol.dart';
 import 'package:note_vision/core/theme/app_theme.dart';
 import 'package:note_vision/core/theme/responsive_layout.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
 import 'package:note_vision/features/editor/presentation/editor_shell_screen.dart';
+import 'package:note_vision/features/musicXML/musicxml_parser_service.dart';
+import 'package:note_vision/features/musicXML/musicxml_score_converter.dart';
 import 'package:note_vision/features/detection/data/tflite_symbol_detector.dart';
 import 'package:note_vision/features/preprocessing/data/basic_image_preprocessor.dart';
 import 'package:note_vision/features/scan/presentation/scan_viewmodel.dart';
@@ -23,6 +32,9 @@ class ScanScreen extends StatefulWidget {
 }
 
 class _ScanScreenState extends State<ScanScreen> {
+  static const _xmlParser = MusicXmlParserService();
+  static const _xmlConverter = MusicXmlScoreConverter();
+
   @override
   void initState() {
     super.initState();
@@ -56,6 +68,13 @@ class _ScanScreenState extends State<ScanScreen> {
           ),
         ),
         centerTitle: true,
+        actions: [
+          IconButton(
+            tooltip: 'Import MusicXML/JSON',
+            onPressed: _importFromFile,
+            icon: const Icon(Icons.file_upload_outlined),
+          ),
+        ],
       ),
       body: switch (vm.state) {
         ScanState.idle         => const SizedBox(),
@@ -92,6 +111,7 @@ class _ScanScreenState extends State<ScanScreen> {
               padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
               child: ScanActions(
                 onRedo: () => Navigator.pop(context),
+                onImport: _importFromFile,
                 canContinue: vm.result?.hasDetections ?? false,
                 onContinue: () {
             final mappedScore = vm.mappingResult?.score ??
@@ -122,6 +142,147 @@ class _ScanScreenState extends State<ScanScreen> {
           ],
         );
       },
+    );
+  }
+
+  Future<void> _importFromFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowMultiple: false,
+      withData: true,
+      allowedExtensions: const ['json', 'xml', 'musicxml'],
+    );
+
+    if (!mounted || result == null || result.files.isEmpty) return;
+    final file = result.files.single;
+    final fileName = file.name;
+    final ext = fileName.split('.').last.toLowerCase();
+    final data = file.bytes;
+    if (data == null) {
+      _showImportError('Unable to read "$fileName".');
+      return;
+    }
+
+    try {
+      final importedScore = switch (ext) {
+        'json' => _scoreFromJson(utf8.decode(data)),
+        'xml' || 'musicxml' => _scoreFromMusicXml(utf8.decode(data)),
+        _ => throw const FormatException('Unsupported import type.'),
+      };
+      if (!mounted) return;
+      Navigator.pushNamed(
+        context,
+        EditorShellScreen.routeName,
+        arguments: EditorShellArgs(
+          score: importedScore,
+          initialState: EditorState(score: importedScore),
+        ),
+      );
+    } catch (_) {
+      _showImportError(
+        'Could not import "$fileName". Use a valid MusicXML or score JSON file.',
+      );
+    }
+  }
+
+  Score _scoreFromMusicXml(String content) {
+    final parsed = _xmlParser.parse(content);
+    if (!parsed.success || parsed.document == null) {
+      throw const FormatException('Invalid MusicXML');
+    }
+    return _xmlConverter.convert(parsed.document!);
+  }
+
+  Score _scoreFromJson(String content) {
+    final root = jsonDecode(content);
+    if (root is! Map) {
+      throw const FormatException('JSON root must be an object');
+    }
+    final rootMap = Map<String, dynamic>.from(root);
+
+    final partMaps = (rootMap['parts'] as List?)
+            ?.whereType<Map>()
+            .map((part) => Map<String, dynamic>.from(part))
+            .toList() ??
+        [];
+    if (partMaps.isEmpty) {
+      throw const FormatException('Score JSON must include parts');
+    }
+
+    final parts = partMaps.map((part) {
+      final measureMaps = (part['measures'] as List?)
+              ?.whereType<Map>()
+              .map((measure) => Map<String, dynamic>.from(measure))
+              .toList() ??
+          [];
+      return Part(
+        id: (part['id']?.toString().isNotEmpty ?? false) ? part['id'].toString() : 'P1',
+        name: part['name']?.toString() ?? 'Part 1',
+        measures: measureMaps.map(_measureFromJson).toList(),
+      );
+    }).toList();
+
+    return Score(
+      id: rootMap['id']?.toString() ?? 'imported-score',
+      title: rootMap['title']?.toString() ?? 'Imported Score',
+      composer: rootMap['composer']?.toString() ?? 'Unknown',
+      parts: parts,
+    );
+  }
+
+  Measure _measureFromJson(Map<String, dynamic> measure) {
+    final symbolMaps = (measure['symbols'] as List?)
+            ?.whereType<Map>()
+            .map((symbol) => Map<String, dynamic>.from(symbol))
+            .toList() ??
+        [];
+    return Measure(
+      number: (measure['number'] as num?)?.toInt() ?? 1,
+      symbols: symbolMaps.map(_symbolFromJson).toList(),
+    );
+  }
+
+  ScoreSymbol _symbolFromJson(Map<String, dynamic> symbol) {
+    final type = symbol['type']?.toString().toLowerCase();
+    if (type == 'rest') {
+      return Rest(
+        duration: (symbol['duration'] as num?)?.toInt() ?? 1,
+        type: symbol['restType']?.toString() ?? symbol['noteType']?.toString() ?? 'quarter',
+        voice: (symbol['voice'] as num?)?.toInt(),
+        staff: (symbol['staff'] as num?)?.toInt(),
+      );
+    }
+
+    final pitch = symbol['pitch']?.toString().toUpperCase() ?? 'C4';
+    final match = RegExp(r'^([A-G])([#B]*)(\d)$').firstMatch(pitch);
+    final step = match?.group(1) ?? symbol['step']?.toString().toUpperCase() ?? 'C';
+    final accidental = match?.group(2) ?? '';
+    final alter = accidental.isEmpty
+        ? (symbol['alter'] as num?)?.toInt()
+        : accidental.replaceAll('B', 'b').split('').fold<int>(
+            0,
+            (value, c) => value + (c == '#' ? 1 : c == 'b' ? -1 : 0),
+          );
+    final octave = int.tryParse(match?.group(3) ?? '') ?? (symbol['octave'] as num?)?.toInt() ?? 4;
+
+    return Note(
+      step: step,
+      octave: octave,
+      alter: alter,
+      duration: (symbol['duration'] as num?)?.toInt() ?? 1,
+      type: symbol['noteType']?.toString() ?? symbol['typeName']?.toString() ?? 'quarter',
+      voice: (symbol['voice'] as num?)?.toInt(),
+      staff: (symbol['staff'] as num?)?.toInt(),
+    );
+  }
+
+  void _showImportError(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        behavior: SnackBarBehavior.floating,
+      ),
     );
   }
 

--- a/lib/features/scan/presentation/scan_screen.dart
+++ b/lib/features/scan/presentation/scan_screen.dart
@@ -1,20 +1,11 @@
 import 'dart:typed_data';
-import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:provider/provider.dart';
-import 'package:note_vision/core/models/note.dart';
-import 'package:note_vision/core/models/measure.dart';
-import 'package:note_vision/core/models/part.dart';
-import 'package:note_vision/core/models/rest.dart';
 import 'package:note_vision/core/models/score.dart';
-import 'package:note_vision/core/models/score_symbol.dart';
 import 'package:note_vision/core/theme/app_theme.dart';
 import 'package:note_vision/core/theme/responsive_layout.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
 import 'package:note_vision/features/editor/presentation/editor_shell_screen.dart';
-import 'package:note_vision/features/musicXML/musicxml_parser_service.dart';
-import 'package:note_vision/features/musicXML/musicxml_score_converter.dart';
 import 'package:note_vision/features/detection/data/tflite_symbol_detector.dart';
 import 'package:note_vision/features/preprocessing/data/basic_image_preprocessor.dart';
 import 'package:note_vision/features/scan/presentation/scan_viewmodel.dart';
@@ -32,9 +23,6 @@ class ScanScreen extends StatefulWidget {
 }
 
 class _ScanScreenState extends State<ScanScreen> {
-  static const _xmlParser = MusicXmlParserService();
-  static const _xmlConverter = MusicXmlScoreConverter();
-
   @override
   void initState() {
     super.initState();
@@ -68,13 +56,6 @@ class _ScanScreenState extends State<ScanScreen> {
           ),
         ),
         centerTitle: true,
-        actions: [
-          IconButton(
-            tooltip: 'Import MusicXML/JSON',
-            onPressed: _importFromFile,
-            icon: const Icon(Icons.file_upload_outlined),
-          ),
-        ],
       ),
       body: switch (vm.state) {
         ScanState.idle         => const SizedBox(),
@@ -111,7 +92,6 @@ class _ScanScreenState extends State<ScanScreen> {
               padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
               child: ScanActions(
                 onRedo: () => Navigator.pop(context),
-                onImport: _importFromFile,
                 canContinue: vm.result?.hasDetections ?? false,
                 onContinue: () {
             final mappedScore = vm.mappingResult?.score ??
@@ -142,147 +122,6 @@ class _ScanScreenState extends State<ScanScreen> {
           ],
         );
       },
-    );
-  }
-
-  Future<void> _importFromFile() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowMultiple: false,
-      withData: true,
-      allowedExtensions: const ['json', 'xml', 'musicxml'],
-    );
-
-    if (!mounted || result == null || result.files.isEmpty) return;
-    final file = result.files.single;
-    final fileName = file.name;
-    final ext = fileName.split('.').last.toLowerCase();
-    final data = file.bytes;
-    if (data == null) {
-      _showImportError('Unable to read "$fileName".');
-      return;
-    }
-
-    try {
-      final importedScore = switch (ext) {
-        'json' => _scoreFromJson(utf8.decode(data)),
-        'xml' || 'musicxml' => _scoreFromMusicXml(utf8.decode(data)),
-        _ => throw const FormatException('Unsupported import type.'),
-      };
-      if (!mounted) return;
-      Navigator.pushNamed(
-        context,
-        EditorShellScreen.routeName,
-        arguments: EditorShellArgs(
-          score: importedScore,
-          initialState: EditorState(score: importedScore),
-        ),
-      );
-    } catch (_) {
-      _showImportError(
-        'Could not import "$fileName". Use a valid MusicXML or score JSON file.',
-      );
-    }
-  }
-
-  Score _scoreFromMusicXml(String content) {
-    final parsed = _xmlParser.parse(content);
-    if (!parsed.success || parsed.document == null) {
-      throw const FormatException('Invalid MusicXML');
-    }
-    return _xmlConverter.convert(parsed.document!);
-  }
-
-  Score _scoreFromJson(String content) {
-    final root = jsonDecode(content);
-    if (root is! Map) {
-      throw const FormatException('JSON root must be an object');
-    }
-    final rootMap = Map<String, dynamic>.from(root);
-
-    final partMaps = (rootMap['parts'] as List?)
-            ?.whereType<Map>()
-            .map((part) => Map<String, dynamic>.from(part))
-            .toList() ??
-        [];
-    if (partMaps.isEmpty) {
-      throw const FormatException('Score JSON must include parts');
-    }
-
-    final parts = partMaps.map((part) {
-      final measureMaps = (part['measures'] as List?)
-              ?.whereType<Map>()
-              .map((measure) => Map<String, dynamic>.from(measure))
-              .toList() ??
-          [];
-      return Part(
-        id: (part['id']?.toString().isNotEmpty ?? false) ? part['id'].toString() : 'P1',
-        name: part['name']?.toString() ?? 'Part 1',
-        measures: measureMaps.map(_measureFromJson).toList(),
-      );
-    }).toList();
-
-    return Score(
-      id: rootMap['id']?.toString() ?? 'imported-score',
-      title: rootMap['title']?.toString() ?? 'Imported Score',
-      composer: rootMap['composer']?.toString() ?? 'Unknown',
-      parts: parts,
-    );
-  }
-
-  Measure _measureFromJson(Map<String, dynamic> measure) {
-    final symbolMaps = (measure['symbols'] as List?)
-            ?.whereType<Map>()
-            .map((symbol) => Map<String, dynamic>.from(symbol))
-            .toList() ??
-        [];
-    return Measure(
-      number: (measure['number'] as num?)?.toInt() ?? 1,
-      symbols: symbolMaps.map(_symbolFromJson).toList(),
-    );
-  }
-
-  ScoreSymbol _symbolFromJson(Map<String, dynamic> symbol) {
-    final type = symbol['type']?.toString().toLowerCase();
-    if (type == 'rest') {
-      return Rest(
-        duration: (symbol['duration'] as num?)?.toInt() ?? 1,
-        type: symbol['restType']?.toString() ?? symbol['noteType']?.toString() ?? 'quarter',
-        voice: (symbol['voice'] as num?)?.toInt(),
-        staff: (symbol['staff'] as num?)?.toInt(),
-      );
-    }
-
-    final pitch = symbol['pitch']?.toString().toUpperCase() ?? 'C4';
-    final match = RegExp(r'^([A-G])([#B]*)(\d)$').firstMatch(pitch);
-    final step = match?.group(1) ?? symbol['step']?.toString().toUpperCase() ?? 'C';
-    final accidental = match?.group(2) ?? '';
-    final alter = accidental.isEmpty
-        ? (symbol['alter'] as num?)?.toInt()
-        : accidental.replaceAll('B', 'b').split('').fold<int>(
-            0,
-            (value, c) => value + (c == '#' ? 1 : c == 'b' ? -1 : 0),
-          );
-    final octave = int.tryParse(match?.group(3) ?? '') ?? (symbol['octave'] as num?)?.toInt() ?? 4;
-
-    return Note(
-      step: step,
-      octave: octave,
-      alter: alter,
-      duration: (symbol['duration'] as num?)?.toInt() ?? 1,
-      type: symbol['noteType']?.toString() ?? symbol['typeName']?.toString() ?? 'quarter',
-      voice: (symbol['voice'] as num?)?.toInt(),
-      staff: (symbol['staff'] as num?)?.toInt(),
-    );
-  }
-
-  void _showImportError(String message) {
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(message),
-        behavior: SnackBarBehavior.floating,
-      ),
     );
   }
 

--- a/lib/features/scan/presentation/scan_screen.dart
+++ b/lib/features/scan/presentation/scan_screen.dart
@@ -68,13 +68,6 @@ class _ScanScreenState extends State<ScanScreen> {
           ),
         ),
         centerTitle: true,
-        actions: [
-          IconButton(
-            tooltip: 'Import MusicXML/JSON',
-            onPressed: _importFromFile,
-            icon: const Icon(Icons.file_upload_outlined),
-          ),
-        ],
       ),
       body: switch (vm.state) {
         ScanState.idle         => const SizedBox(),
@@ -110,7 +103,6 @@ class _ScanScreenState extends State<ScanScreen> {
           padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
           child: ScanActions(
             onRedo: () => Navigator.pop(context),
-            onImport: _importFromFile,
             canContinue: vm.result?.hasDetections ?? false,
             onContinue: () {
               final mappedScore = vm.mappingResult?.score ??

--- a/lib/features/scan/presentation/widgets/scan_actions.dart
+++ b/lib/features/scan/presentation/widgets/scan_actions.dart
@@ -4,12 +4,14 @@ class ScanActions extends StatelessWidget {
   final VoidCallback onRedo;
   final VoidCallback onContinue;
   final VoidCallback? onImport;
+  final bool canContinue;
 
   const ScanActions({
     super.key,
     required this.onRedo,
     required this.onContinue,
     this.onImport,
+    this.canContinue = true,
   });
 
   // ── Design tokens ──────────────────────────────────────────────────────────
@@ -41,7 +43,7 @@ class ScanActions extends StatelessWidget {
                   borderRadius: BorderRadius.circular(14),
                   border: Border.all(color: _border),
                 ),
-                child: const Row(
+                child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     Icon(Icons.redo_outlined, size: 18, color: _textMuted),
@@ -73,7 +75,7 @@ class ScanActions extends StatelessWidget {
                     borderRadius: BorderRadius.circular(14),
                     border: Border.all(color: _border),
                   ),
-                  child: const Row(
+                  child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Icon(Icons.file_upload_outlined, size: 18, color: _textMuted),
@@ -99,11 +101,11 @@ class ScanActions extends StatelessWidget {
           Expanded(
             flex: onImport == null ? 2 : 1,
             child: _TappableButton(
-              onPressed: onContinue,
+              onPressed: canContinue ? onContinue : null,
               child: Container(
                 height: 52,
                 decoration: BoxDecoration(
-                  color: _textPrimary,
+                  color: canContinue ? _textPrimary : _border,
                   borderRadius: BorderRadius.circular(14),
                   boxShadow: [
                     BoxShadow(
@@ -113,7 +115,7 @@ class ScanActions extends StatelessWidget {
                     ),
                   ],
                 ),
-                child: const Row(
+                child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     Text(
@@ -121,12 +123,16 @@ class ScanActions extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 14,
                         fontWeight: FontWeight.w600,
-                        color: _bg,
+                        color: canContinue ? _bg : _textMuted,
                         letterSpacing: 0.3,
                       ),
                     ),
                     SizedBox(width: 8),
-                    Icon(Icons.arrow_forward, size: 18, color: _bg),
+                    Icon(
+                      Icons.arrow_forward,
+                      size: 18,
+                      color: canContinue ? _bg : _textMuted,
+                    ),
                   ],
                 ),
               ),
@@ -142,7 +148,7 @@ class ScanActions extends StatelessWidget {
 
 class _TappableButton extends StatefulWidget {
   final Widget child;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   const _TappableButton({required this.child, required this.onPressed});
 
@@ -156,12 +162,14 @@ class _TappableButtonState extends State<_TappableButton> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTapDown: (_) => setState(() => _pressed = true),
-      onTapUp: (_) {
-        setState(() => _pressed = false);
-        widget.onPressed();
-      },
-      onTapCancel: () => setState(() => _pressed = false),
+      onTapDown: widget.onPressed == null ? null : (_) => setState(() => _pressed = true),
+      onTapUp: widget.onPressed == null
+          ? null
+          : (_) {
+              setState(() => _pressed = false);
+              widget.onPressed!();
+            },
+      onTapCancel: widget.onPressed == null ? null : () => setState(() => _pressed = false),
       child: AnimatedScale(
         scale: _pressed ? 0.97 : 1.0,
         duration: const Duration(milliseconds: 100),

--- a/lib/features/scan/presentation/widgets/scan_actions.dart
+++ b/lib/features/scan/presentation/widgets/scan_actions.dart
@@ -14,137 +14,155 @@ class ScanActions extends StatelessWidget {
     this.canContinue = true,
   });
 
-  // ── Design tokens ──────────────────────────────────────────────────────────
-  static const _bg          = Color(0xFF0D0D0D);
-  static const _surface     = Color(0xFF1A1A1A);
-  static const _border      = Color(0xFF2C2C2C);
-  static const _accent      = Color(0xFFD4A96A);
+  static const _bg = Color(0xFF0D0D0D);
+  static const _surface = Color(0xFF1A1A1A);
+  static const _border = Color(0xFF2C2C2C);
+  static const _accent = Color(0xFFD4A96A);
   static const _textPrimary = Color(0xFFFFFFFF);
-  static const _textMuted   = Color(0xFF8A8A8A);
+  static const _textMuted = Color(0xFF8A8A8A);
 
   @override
   Widget build(BuildContext context) {
+    final isLandscape = MediaQuery.of(context).orientation == Orientation.landscape;
+    final stackButtons = isLandscape && onImport != null;
+
     return Container(
       padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
       decoration: const BoxDecoration(
         color: _bg,
         border: Border(top: BorderSide(color: _border, width: 0.5)),
       ),
-      child: Row(
-        children: [
-          // ── Redo (ghost) ─────────────────────────────────────────────
-          Expanded(
-            child: _TappableButton(
-              onPressed: onRedo,
-              child: Container(
-                height: 52,
-                decoration: BoxDecoration(
-                  color: _surface,
-                  borderRadius: BorderRadius.circular(14),
-                  border: Border.all(color: _border),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
+      child: stackButtons
+          ? Column(
+              children: [
+                Row(
                   children: [
-                    Icon(Icons.redo_outlined, size: 18, color: _textMuted),
-                    SizedBox(width: 8),
-                    Text(
-                      'Redo',
-                      style: TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w400,
-                        color: _textMuted,
-                        letterSpacing: 0.3,
-                      ),
-                    ),
+                    Expanded(child: _buildRedoButton()),
+                    const SizedBox(width: 12),
+                    Expanded(child: _buildImportButton()),
                   ],
                 ),
-              ),
+                const SizedBox(height: 12),
+                SizedBox(width: double.infinity, child: _buildContinueButton(flex: 1)),
+              ],
+            )
+          : Row(
+              children: [
+                Expanded(child: _buildRedoButton()),
+                const SizedBox(width: 12),
+                if (onImport != null) ...[
+                  Expanded(child: _buildImportButton()),
+                  const SizedBox(width: 12),
+                ],
+                _buildContinueButton(flex: onImport == null ? 2 : 1),
+              ],
             ),
-          ),
+    );
+  }
 
-          const SizedBox(width: 12),
-          if (onImport != null) ...[
-            Expanded(
-              child: _TappableButton(
-                onPressed: onImport!,
-                child: Container(
-                  height: 52,
-                  decoration: BoxDecoration(
-                    color: _surface,
-                    borderRadius: BorderRadius.circular(14),
-                    border: Border.all(color: _border),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(Icons.file_upload_outlined, size: 18, color: _textMuted),
-                      SizedBox(width: 8),
-                      Text(
-                        'Import',
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w400,
-                          color: _textMuted,
-                          letterSpacing: 0.3,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
+  Widget _buildRedoButton() {
+    return _TappableButton(
+      onPressed: onRedo,
+      child: Container(
+        height: 52,
+        decoration: BoxDecoration(
+          color: _surface,
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: _border),
+        ),
+        child: const Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.redo_outlined, size: 18, color: _textMuted),
+            SizedBox(width: 8),
+            Text(
+              'Redo',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w400,
+                color: _textMuted,
+                letterSpacing: 0.3,
               ),
             ),
-            const SizedBox(width: 12),
           ],
+        ),
+      ),
+    );
+  }
 
-          // ── Continue (primary) ───────────────────────────────────────
-          Expanded(
-            flex: onImport == null ? 2 : 1,
-            child: _TappableButton(
-              onPressed: canContinue ? onContinue : null,
-              child: Container(
-                height: 52,
-                decoration: BoxDecoration(
-                  color: canContinue ? _textPrimary : _border,
-                  borderRadius: BorderRadius.circular(14),
-                  boxShadow: [
-                    BoxShadow(
-                      color: _accent.withValues(alpha: 0.18),
-                      blurRadius: 20,
-                      offset: const Offset(0, 6),
-                    ),
-                  ],
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      'Continue',
-                      style: TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                        color: canContinue ? _bg : _textMuted,
-                        letterSpacing: 0.3,
-                      ),
-                    ),
-                    SizedBox(width: 8),
-                    Icon(
-                      Icons.arrow_forward,
-                      size: 18,
-                      color: canContinue ? _bg : _textMuted,
-                    ),
-                  ],
-                ),
+  Widget _buildImportButton() {
+    return _TappableButton(
+      onPressed: onImport,
+      child: Container(
+        height: 52,
+        decoration: BoxDecoration(
+          color: _surface,
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: _border),
+        ),
+        child: const Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.file_upload_outlined, size: 18, color: _textMuted),
+            SizedBox(width: 8),
+            Text(
+              'Import',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w400,
+                color: _textMuted,
+                letterSpacing: 0.3,
               ),
             ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContinueButton({required int flex}) {
+    return Expanded(
+      flex: flex,
+      child: _TappableButton(
+        onPressed: canContinue ? onContinue : null,
+        child: Container(
+          height: 52,
+          decoration: BoxDecoration(
+            color: canContinue ? _textPrimary : _border,
+            borderRadius: BorderRadius.circular(14),
+            boxShadow: [
+              BoxShadow(
+                color: _accent.withValues(alpha: 0.18),
+                blurRadius: 20,
+                offset: const Offset(0, 6),
+              ),
+            ],
           ),
-        ],
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                'Continue',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: canContinue ? _bg : _textMuted,
+                  letterSpacing: 0.3,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Icon(
+                Icons.arrow_forward,
+                size: 18,
+                color: canContinue ? _bg : _textMuted,
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
 }
-
-// ─── Tappable button wrapper ──────────────────────────────────────────────────
 
 class _TappableButton extends StatefulWidget {
   final Widget child;
@@ -163,13 +181,13 @@ class _TappableButtonState extends State<_TappableButton> {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTapDown: widget.onPressed == null ? null : (_) => setState(() => _pressed = true),
-      onTapUp: widget.onPressed == null
+      onTapCancel: widget.onPressed == null ? null : () => setState(() => _pressed = false),
+      onTap: widget.onPressed == null
           ? null
-          : (_) {
+          : () {
               setState(() => _pressed = false);
               widget.onPressed!();
             },
-      onTapCancel: widget.onPressed == null ? null : () => setState(() => _pressed = false),
       child: AnimatedScale(
         scale: _pressed ? 0.97 : 1.0,
         duration: const Duration(milliseconds: 100),


### PR DESCRIPTION
### Motivation
- Users should be able to import MusicXML files from the capture flow and preview validation messages before entering the editor. 
- Prevent advancing to the editor when a scan produced no detections and improve inspector preview legibility for developers.

### Description
- Added a new `ImportScoreScreen` providing MusicXML import, validation via `MusicXmlValidatorService`, preview rendering, and a gated `Continue` button to open the editor only when a valid score is loaded (`lib/features/capture/presentation/import_score_screen.dart`).
- Wired the Capture bottom-bar `Import` action to navigate to the new import screen instead of immediately opening the gallery (`lib/features/capture/presentation/capture_screen.dart`).
- Added a temporary developer-only `Import JSON (DEV)` action on the import screen to load score JSON fixtures for testing and surfaced JSON import errors in the UI (`lib/features/capture/presentation/import_score_screen.dart`).
- Disabled the Scan `Continue` action when there are no detections by adding a `canContinue` flag to `ScanActions` and passing `vm.result?.hasDetections ?? false` from the scan screen (`lib/features/scan/presentation/widgets/scan_actions.dart`, `lib/features/scan/presentation/scan_screen.dart`).
- Updated the detection inspector score preview to remove the hard dark background override and use the default notation viewer background for improved readability (`lib/features/detection_inspector/widgets/di_score_preview.dart`).
- Migrated the MusicXML Inspector to the app's dark theme colors for visual consistency (`lib/features/musicxml_inspector/music_inspector_screen.dart`).

### Testing
- Attempted to run `dart format` and `flutter format` on modified files but the CLI tools were unavailable in this environment so formatting could not be executed. 
- Verified repository operations with `git add`/`git commit` and created the PR (commit succeeded). 
- No automated unit or integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e92016b4832084cb74f529557352)