### PR TITLE
Preserve selection when moving a symbol between measures and add regression tests

### DIFF
--- a/lib/features/editor/domain/editor_actions.dart
+++ b/lib/features/editor/domain/editor_actions.dart
@@ -160,7 +160,7 @@ extension EditorActions on EditorState {
       toInsertIndex,
       moved,
     );
-    final toSymbolIndex = toSymbols.length - 1;
+    final toSymbolIndex = toSymbols.length;
 
     return applyEdit(
       score: nextScore,

--- a/test/features/editor/domain/editor_actions_test.dart
+++ b/test/features/editor/domain/editor_actions_test.dart
@@ -112,6 +112,50 @@ void main() {
       expect(identical(state.insertRestAfterSelection(), state), isTrue);
     });
 
+    test('moveSelectedSymbolToMeasureOffset keeps moved symbol selected', () {
+      final score = Score(
+        id: 's-move-measure',
+        title: 't',
+        composer: 'c',
+        parts: const [
+          Part(
+            id: 'p1',
+            name: 'P1',
+            measures: [
+              Measure(
+                number: 1,
+                symbols: [
+                  Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+                  Rest(duration: 1, type: 'quarter'),
+                ],
+              ),
+              Measure(
+                number: 2,
+                symbols: [Rest(duration: 2, type: 'half')],
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final selected = EditorState(score: score).copyWith(
+        selectedPartIndex: 0,
+        selectedMeasureIndex: 0,
+        selectedSymbolIndex: 0,
+        selectedSymbol: score.parts[0].measures[0].symbols[0],
+      );
+
+      final moved = selected.moveSelectedSymbolToMeasureOffset(1);
+
+      expect(moved.selectedPartIndex, 0);
+      expect(moved.selectedMeasureIndex, 1);
+      expect(moved.selectedSymbolIndex, 1);
+      expect(moved.selectedSymbol, isA<Note>());
+      expect((moved.selectedSymbol! as Note).pitch, 'C4');
+      expect(moved.score.parts[0].measures[1].symbols, hasLength(2));
+      expect(moved.undoStack, isNotEmpty);
+    });
+
     test('deleting last symbol keeps measure context so insert can recover', () {
       final score = _baseScore(
         const [Note(step: 'C', octave: 4, duration: 1, type: 'quarter')],

--- a/test/features/editor/domain/mapped_score_editor_regression_test.dart
+++ b/test/features/editor/domain/mapped_score_editor_regression_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:note_vision/core/models/measure.dart';
+import 'package:note_vision/core/models/note.dart';
+import 'package:note_vision/core/models/part.dart';
+import 'package:note_vision/core/models/rest.dart';
+import 'package:note_vision/core/models/score.dart';
+import 'package:note_vision/features/editor/domain/editor_actions.dart';
+import 'package:note_vision/features/editor/model/editor_state.dart';
+
+void main() {
+  group('Mapped score editor regression', () {
+    test('mapped multi-measure symbols remain editable with stable selection', () {
+      final score = _mappedScore();
+      final selectedSymbol = score.parts[0].measures[0].symbols[0];
+      final selectedState = EditorState(score: score).copyWith(
+        selectedPartIndex: 0,
+        selectedMeasureIndex: 0,
+        selectedSymbolIndex: 0,
+        selectedSymbol: selectedSymbol,
+      );
+
+      final reordered = selectedState.reorderSymbolWithinMeasure(
+        measureIndex: 0,
+        fromSymbolIndex: 0,
+        toSymbolIndex: 2,
+      );
+
+      expect(reordered.selectedPartIndex, 0);
+      expect(reordered.selectedMeasureIndex, 0);
+      expect(reordered.selectedSymbolIndex, 2);
+      expect((reordered.selectedSymbol! as Note).pitch, 'E4');
+
+      final movedToNextMeasure = reordered.moveSelectedSymbolToMeasureOffset(1);
+      expect(movedToNextMeasure.selectedMeasureIndex, 1);
+      expect(movedToNextMeasure.selectedSymbolIndex, 1);
+      expect((movedToNextMeasure.selectedSymbol! as Note).pitch, 'E4');
+
+      final deleted = movedToNextMeasure.deleteSelectedSymbol();
+      expect(deleted.selectedMeasureIndex, 1);
+      expect(deleted.selectedSymbolIndex, 0);
+      expect(deleted.selectedSymbol, isA<Rest>());
+
+      final inserted = deleted.insertNoteAfterSelection();
+      expect(inserted.selectedMeasureIndex, 1);
+      expect(inserted.selectedSymbolIndex, 1);
+      expect(inserted.selectedSymbol, isA<Note>());
+      expect(inserted.score.parts[0].measures[1].symbols, hasLength(2));
+    });
+
+    test('partial mapped-style score with unresolved symbols keeps safe empty selection', () {
+      final score = Score(
+        id: 'mapped-partial',
+        title: '',
+        composer: '',
+        parts: const [
+          Part(
+            id: 'P1',
+            name: 'Detected Part',
+            measures: [
+              Measure(number: 1, symbols: []),
+              Measure(number: 2, symbols: [Rest(duration: 1, type: 'quarter')]),
+            ],
+          ),
+        ],
+      );
+
+      final state = EditorState(score: score);
+
+      expect(state.selectedPartIndex, isNull);
+      expect(state.selectedMeasureIndex, isNull);
+      expect(state.selectedSymbolIndex, isNull);
+      expect(state.selectedSymbol, isNull);
+
+      final selected = state.copyWith(
+        selectedPartIndex: 0,
+        selectedMeasureIndex: 1,
+        selectedSymbolIndex: 0,
+        selectedSymbol: score.parts[0].measures[1].symbols[0],
+      );
+
+      expect(selected.selectedMeasureIndex, 1);
+      expect(selected.selectedSymbolIndex, 0);
+      expect(selected.selectedSymbol, isA<Rest>());
+    });
+  });
+}
+
+Score _mappedScore() {
+  return const Score(
+    id: 'mapped-regression',
+    title: '',
+    composer: '',
+    parts: [
+      Part(
+        id: 'P1',
+        name: 'Detected Part',
+        measures: [
+          Measure(
+            number: 1,
+            symbols: [
+              Note(step: 'E', octave: 4, duration: 1, type: 'quarter', staff: 1),
+              Rest(duration: 2, type: 'half', staff: 1),
+              Note(step: 'G', octave: 4, duration: 1, type: 'quarter', staff: 1),
+            ],
+          ),
+          Measure(
+            number: 2,
+            symbols: [
+              Rest(duration: 1, type: 'quarter', staff: 1),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+}


### PR DESCRIPTION
### Motivation

- Ensure that when a symbol is moved to another measure the editor keeps that symbol selected with the correct index, fixing off-by-one selection behavior. 
- Add coverage for mapped/partially-mapped score scenarios to prevent regressions around selection stability and editability.

### Description

- Adjusted selection computation in `moveSelectedSymbolToMeasureOffset` by setting `toSymbolIndex` to `toSymbols.length` so the moved symbol is selected at its new index after insertion. 
- Added a unit test `moveSelectedSymbolToMeasureOffset keeps moved symbol selected` in `test/features/editor/domain/editor_actions_test.dart` to validate selection and undo stack after moving a symbol to the next measure. 
- Added a new regression test file `test/features/editor/domain/mapped_score_editor_regression_test.dart` with tests for mapped multi-measure symbol editing and safe behavior for partially mapped scores.

### Testing

- Ran the editor domain tests including `moveSelectedSymbolToMeasureOffset keeps moved symbol selected`; the new test passed. 
- Ran the mapped score regression group in `mapped_score_editor_regression_test.dart`; both tests in that file passed. 
- All affected unit tests in `test/features/editor/domain/` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8b8d9a6b88320afd79d33fa6d0c8f)