### PR TITLE
Add Music Symbol Palette to editor layout; refine PaletteItem and add widget tests

### DIFF
--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -248,7 +248,14 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                         ? Row(
                             crossAxisAlignment: CrossAxisAlignment.stretch,
                             children: [
-                              Expanded(child: notationPanel),
+                              Expanded(
+                                child: Column(
+                                  children: [
+                                    Expanded(child: notationPanel),
+                                    const MusicSymbolPalette(),
+                                  ],
+                                ),
+                              ),
                               const SizedBox(width: 12),
                               SizedBox(
                                 width: controlPanelWidth,
@@ -266,8 +273,8 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                         : Column(
                             children: [
                               Expanded(child: notationPanel),
-                              statusStrip,
                               const MusicSymbolPalette(),
+                              statusStrip,
                               actionBar,
                             ],
                           ),

--- a/lib/features/editor/presentation/widgets/palette/palette_item.dart
+++ b/lib/features/editor/presentation/widgets/palette/palette_item.dart
@@ -19,8 +19,8 @@ class PaletteItem extends StatelessWidget {
       feedback: Material(
         color: Colors.transparent,
         child: Transform.scale(
-          scale: 1.4, // slightly reduced from 1.55
-          child: _buildSymbolContainer(symbol, scale: 1.4),
+          scale: 1.5,
+          child: _buildSymbolContainer(symbol, scale: 1.5),
         ),
       ),
       childWhenDragging: Opacity(
@@ -33,40 +33,43 @@ class PaletteItem extends StatelessWidget {
   }
 
   Widget _buildSymbolContainer(MusicalSymbol sym, {double scale = 1.0}) {
-    return Container(
-      width: 56, // reduced from 74
-      margin: const EdgeInsets.symmetric(horizontal: 4), // tighter spacing
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            height: 52, // reduced from 70
-            decoration: BoxDecoration(
-              color: const Color(0xFF2C2C2C),
-              borderRadius: BorderRadius.circular(8), // slightly tighter radius
-            ),
-            child: Center(
-              child: CustomPaint(
-                size: Size(34 * scale, 40 * scale), // scaled-down painter
-                painter: MusicalSymbolPainter(
-                  symbol: sym,
-                  color: Colors.white,
+    return Semantics(
+      label: '${sym.label} palette symbol',
+      child: Container(
+        width: 56,
+        margin: const EdgeInsets.symmetric(horizontal: 4),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              height: 52,
+              decoration: BoxDecoration(
+                color: const Color(0xFF2C2C2C),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Center(
+                child: CustomPaint(
+                  size: Size(34 * scale, 40 * scale),
+                  painter: MusicalSymbolPainter(
+                    symbol: sym,
+                    color: Colors.white,
+                  ),
                 ),
               ),
             ),
-          ),
-          const SizedBox(height: 4), // reduced spacing
-          Text(
-            sym.label,
-            style: const TextStyle(
-              fontSize: 9, // smaller text
-              color: Color(0xFF8A8A8A),
-              fontWeight: FontWeight.w500,
-              height: 1.1,
+            const SizedBox(height: 4),
+            Text(
+              sym.label,
+              style: const TextStyle(
+                fontSize: 10,
+                color: Color(0xFF8A8A8A),
+                fontWeight: FontWeight.w500,
+                height: 1.1,
+              ),
+              textAlign: TextAlign.center,
             ),
-            textAlign: TextAlign.center,
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/test/features/editor/presentation/widgets/palette/music_symbol_palette_test.dart
+++ b/test/features/editor/presentation/widgets/palette/music_symbol_palette_test.dart
@@ -55,7 +55,8 @@ void main() {
     final draggable = tester.widget<LongPressDraggable<MusicalSymbol>>(
       find.byType(LongPressDraggable<MusicalSymbol>),
     );
-    final feedbackTransform = draggable.feedback as Transform;
+    final feedbackMaterial = draggable.feedback as Material;
+    final feedbackTransform = feedbackMaterial.child as Transform;
     expect(feedbackTransform.transform.getMaxScaleOnAxis(), closeTo(1.5, 0.001));
 
     final draggingGhost = draggable.childWhenDragging as Opacity;

--- a/test/features/editor/presentation/widgets/palette/music_symbol_palette_test.dart
+++ b/test/features/editor/presentation/widgets/palette/music_symbol_palette_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:note_vision/features/editor/domain/model/musical_symbol.dart';
+import 'package:note_vision/features/editor/presentation/widgets/palette/music_symbol_palette.dart';
+import 'package:note_vision/features/editor/presentation/widgets/palette/palette_item.dart';
+
+void main() {
+  testWidgets('renders all supported palette symbols and labels', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: MusicSymbolPalette(),
+        ),
+      ),
+    );
+
+    expect(find.byType(PaletteItem), findsNWidgets(7));
+    expect(find.text('Whole'), findsOneWidget);
+    expect(find.text('Half'), findsOneWidget);
+    expect(find.text('Quarter'), findsOneWidget);
+    expect(find.text('Eighth'), findsOneWidget);
+    expect(find.text('W Rest'), findsOneWidget);
+    expect(find.text('H Rest'), findsOneWidget);
+    expect(find.text('Q Rest'), findsOneWidget);
+  });
+
+  testWidgets('uses horizontal scrolling and dark themed container', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: MusicSymbolPalette(),
+        ),
+      ),
+    );
+
+    final scrollView = tester.widget<SingleChildScrollView>(find.byType(SingleChildScrollView));
+    expect(scrollView.scrollDirection, Axis.horizontal);
+
+    final paletteContainer = tester.widget<Container>(find.byType(Container).first);
+    final decoration = paletteContainer.decoration as BoxDecoration;
+    expect(decoration.color, const Color(0xFF1A1A1A));
+    final border = decoration.border as Border;
+    expect(border.top.color, const Color(0xFF2C2C2C));
+  });
+
+  testWidgets('palette item drag affordance and label legibility match spec', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PaletteItem(symbol: MusicalSymbol.wholeNote),
+        ),
+      ),
+    );
+
+    final draggable = tester.widget<LongPressDraggable<MusicalSymbol>>(
+      find.byType(LongPressDraggable<MusicalSymbol>),
+    );
+    final feedbackTransform = draggable.feedback as Transform;
+    expect(feedbackTransform.transform.getMaxScaleOnAxis(), closeTo(1.5, 0.001));
+
+    final draggingGhost = draggable.childWhenDragging as Opacity;
+    expect(draggingGhost.opacity, 0.32);
+
+    final label = tester.widget<Text>(find.text('Whole'));
+    expect(label.style?.fontSize, 10);
+    expect(label.style?.color, const Color(0xFF8A8A8A));
+  });
+}


### PR DESCRIPTION
### Motivation
- Surface the music symbol palette in both landscape and portrait editor layouts so users can access drag-and-drop symbols more easily.
- Improve the visual fidelity and accessibility of individual palette items for better legibility and assistive support.
- Add automated widget tests to verify palette rendering and behavior.

### Description
- Inserted `MusicSymbolPalette` into the editor shell layout: in landscape it appears below the notation panel (wrapped in a `Column`), and in portrait it is placed between the notation panel and the `statusStrip`.
- Updated `PaletteItem` to include a `Semantics` label, adjusted drag feedback scale to `1.5`, tuned container sizing and spacing, centered labels, and increased label font size to `10` for improved legibility.
- Kept the `LongPressDraggable` behavior and child opacity while dragging (`opacity: 0.32`) and ensured painter scaling honors the `scale` parameter.
- Added widget tests in `test/features/editor/presentation/widgets/palette/music_symbol_palette_test.dart` to assert palette item counts, labels, scroll behavior, container styling, and drag affordance.

### Testing
- Ran the new widget tests in `music_symbol_palette_test.dart` which include three `testWidgets` cases asserting rendering, scrolling/styling, and drag/label properties, and all tests passed when run with `flutter test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cddb1f0afc8320a1d3df1d2ac94602)