### PR TITLE
Add palette drag-and-drop insertion with insertion indicator and measure target utilities

### DIFF
--- a/lib/core/widgets/score_notation/score_notation_painter.dart
+++ b/lib/core/widgets/score_notation/score_notation_painter.dart
@@ -21,6 +21,7 @@ class ScoreNotationPainter extends CustomPainter {
     this.selectedMeasureIndex,
     this.selectedSymbolIndex,
     this.dragFeedback,
+    this.insertionIndicator,
   });
 
   final List<Measure> measures;
@@ -32,6 +33,7 @@ class ScoreNotationPainter extends CustomPainter {
   final int? selectedMeasureIndex;
   final int? selectedSymbolIndex;
   final NotationDragFeedback? dragFeedback;
+  final NotationInsertionIndicator? insertionIndicator;
 
   static const double staffLineSpacing = 12;
   static const double tapTargetSize = 24;
@@ -143,6 +145,56 @@ class ScoreNotationPainter extends CustomPainter {
             ),
           );
         }
+      }
+    }
+    return targets;
+  }
+
+  static List<NotationMeasureTarget> buildMeasureTargets({
+    required List<Measure> measures,
+    required int measuresPerRow,
+    required double minMeasureWidth,
+    required double rowHeight,
+    required EdgeInsets padding,
+    required double rowPrefixWidth,
+  }) {
+    final rows = _buildRowMetricsStatic(
+      measures: measures,
+      measuresPerRow: measuresPerRow,
+      rowHeight: rowHeight,
+      padding: padding,
+      rowPrefixWidth: rowPrefixWidth,
+      minMeasureWidth: minMeasureWidth,
+    );
+    final targets = <NotationMeasureTarget>[];
+    for (final row in rows) {
+      for (var measureInRow = 0; measureInRow < row.measures.length; measureInRow++) {
+        final measure = row.measures[measureInRow];
+        final measureStartX = row.contentStartX + (measureInRow * minMeasureWidth);
+        final measureEndX = measureStartX + minMeasureWidth;
+        targets.add(
+          NotationMeasureTarget(
+            measureIndex: row.globalStartMeasureIndex + measureInRow,
+            measureRect: Rect.fromLTRB(
+              measureStartX,
+              row.staffTop,
+              measureEndX,
+              row.staffBottom,
+            ),
+            lineYs: List<double>.generate(
+              5,
+              (index) => row.staffTop + (index * staffLineSpacing),
+              growable: false,
+            ),
+            symbolCentersX: _symbolCentersX(
+              measure,
+              measureStartX: measureStartX,
+              measureEndX: measureEndX,
+            ),
+            innerStartX: measureStartX + 16,
+            innerEndX: measureEndX - 16,
+          ),
+        );
       }
     }
     return targets;
@@ -264,7 +316,68 @@ class ScoreNotationPainter extends CustomPainter {
         staffTop: row.staffTop,
         staffBottom: row.staffBottom,
       );
+
+      final indicator = insertionIndicator;
+      if (indicator != null &&
+          indicator.measureIndex == row.globalStartMeasureIndex + measureInRow) {
+        final indicatorX = _insertionLineX(
+          symbolCentersX: _symbolCentersX(
+            measure,
+            measureStartX: measureX,
+            measureEndX: nextMeasureX,
+          ),
+          insertIndex: indicator.insertIndex,
+          measureStartX: measureX,
+          measureEndX: nextMeasureX,
+        );
+        final paint = Paint()
+          ..color = const Color(0xFF3B82F6)
+          ..strokeWidth = 2
+          ..strokeCap = StrokeCap.round;
+        canvas.drawLine(
+          Offset(indicatorX, row.staffTop - 8),
+          Offset(indicatorX, row.staffBottom + 8),
+          paint,
+        );
+      }
     }
+  }
+
+  static List<double> _symbolCentersX(
+    Measure measure, {
+    required double measureStartX,
+    required double measureEndX,
+  }) {
+    if (measure.symbols.isEmpty) return const [];
+    const innerPadding = 16.0;
+    final drawableWidth = math.max(
+      12.0,
+      (measureEndX - measureStartX) - (innerPadding * 2),
+    );
+    return List<double>.generate(measure.symbols.length, (symbolIndex) {
+      final progress = (symbolIndex + 1) / (measure.symbols.length + 1);
+      return measureStartX + innerPadding + (drawableWidth * progress);
+    }, growable: false);
+  }
+
+  static double _insertionLineX({
+    required List<double> symbolCentersX,
+    required int insertIndex,
+    required double measureStartX,
+    required double measureEndX,
+  }) {
+    const innerPadding = 16.0;
+    final clampedIndex = insertIndex.clamp(0, symbolCentersX.length);
+    final innerStart = measureStartX + innerPadding;
+    final innerEnd = measureEndX - innerPadding;
+    if (symbolCentersX.isEmpty) {
+      return (innerStart + innerEnd) / 2;
+    }
+    if (clampedIndex == 0) return (innerStart + symbolCentersX.first) / 2;
+    if (clampedIndex == symbolCentersX.length) {
+      return (symbolCentersX.last + innerEnd) / 2;
+    }
+    return (symbolCentersX[clampedIndex - 1] + symbolCentersX[clampedIndex]) / 2;
   }
 
   void _drawMeasureSymbols(
@@ -652,7 +765,8 @@ class ScoreNotationPainter extends CustomPainter {
         oldDelegate.rowPrefixWidth != rowPrefixWidth ||
         oldDelegate.selectedMeasureIndex != selectedMeasureIndex ||
         oldDelegate.selectedSymbolIndex != selectedSymbolIndex ||
-        oldDelegate.dragFeedback != dragFeedback;
+        oldDelegate.dragFeedback != dragFeedback ||
+        oldDelegate.insertionIndicator != insertionIndicator;
   }
 }
 
@@ -699,6 +813,45 @@ class NotationDragFeedback {
       draggedSymbolIndex.hashCode ^
       targetSymbolIndex.hashCode ^
       dragX.hashCode;
+}
+
+class NotationInsertionIndicator {
+  const NotationInsertionIndicator({
+    required this.measureIndex,
+    required this.insertIndex,
+  });
+
+  final int measureIndex;
+  final int insertIndex;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NotationInsertionIndicator &&
+          runtimeType == other.runtimeType &&
+          measureIndex == other.measureIndex &&
+          insertIndex == other.insertIndex;
+
+  @override
+  int get hashCode => measureIndex.hashCode ^ insertIndex.hashCode;
+}
+
+class NotationMeasureTarget {
+  const NotationMeasureTarget({
+    required this.measureIndex,
+    required this.measureRect,
+    required this.lineYs,
+    required this.symbolCentersX,
+    required this.innerStartX,
+    required this.innerEndX,
+  });
+
+  final int measureIndex;
+  final Rect measureRect;
+  final List<double> lineYs;
+  final List<double> symbolCentersX;
+  final double innerStartX;
+  final double innerEndX;
 }
 
 class _RowMetrics {

--- a/lib/core/widgets/score_notation_viewer.dart
+++ b/lib/core/widgets/score_notation_viewer.dart
@@ -23,6 +23,7 @@ class ScoreNotationViewer extends StatefulWidget {
     this.selectedSymbolIndex,
     this.onSymbolTap,
     this.onSymbolReorder,
+    this.insertionIndicator,
   });
 
   final Score? score;
@@ -35,6 +36,7 @@ class ScoreNotationViewer extends StatefulWidget {
   final int? selectedSymbolIndex;
   final ValueChanged<NotationSymbolTarget?>? onSymbolTap;
   final ValueChanged<NotationSymbolReorder>? onSymbolReorder;
+  final NotationInsertionIndicator? insertionIndicator;
 
   @override
   State<ScoreNotationViewer> createState() => _ScoreNotationViewerState();
@@ -117,6 +119,7 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
                 targetSymbolIndex: _dragSession!.toSymbolIndex,
                 dragX: _dragSession!.dragPosition.dx,
               ),
+        insertionIndicator: widget.insertionIndicator,
       ),
     );
   }

--- a/lib/features/editor/domain/editor_actions.dart
+++ b/lib/features/editor/domain/editor_actions.dart
@@ -98,6 +98,35 @@ extension EditorActions on EditorState {
     );
   }
 
+  EditorState insertSymbolAtPosition({
+    required int measureIndex,
+    required int symbolIndex,
+    required ScoreSymbol symbol,
+    int partIndex = 0,
+  }) {
+    if (partIndex < 0 || partIndex >= score.parts.length) return this;
+    final measures = score.parts[partIndex].measures;
+    if (measureIndex < 0 || measureIndex >= measures.length) return this;
+    if (symbolIndex < 0 || symbolIndex > measures[measureIndex].symbols.length) {
+      return this;
+    }
+
+    final nextScore = score.insertSymbolAt(
+      partIndex,
+      measureIndex,
+      symbolIndex,
+      symbol,
+    );
+
+    return applyEdit(
+      score: nextScore,
+      selectedPartIndex: partIndex,
+      selectedMeasureIndex: measureIndex,
+      selectedSymbolIndex: symbolIndex,
+      selectedSymbol: symbol,
+    );
+  }
+
   EditorState deleteSelectedSymbol() {
     if (!hasSelection) return this;
 

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -1,14 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:note_vision/core/models/clef.dart';
 import 'package:note_vision/core/models/note.dart';
 import 'package:note_vision/core/models/rest.dart';
+import 'package:note_vision/core/models/score_symbol.dart';
 import 'package:note_vision/core/models/score.dart';
 import 'package:note_vision/core/theme/app_theme.dart';
 import 'package:note_vision/core/theme/responsive_layout.dart';
+import 'package:note_vision/core/widgets/score_notation/notation_layout.dart';
+import 'package:note_vision/core/widgets/score_notation/score_notation_painter.dart';
 import 'package:note_vision/core/widgets/score_notation_viewer.dart';
+import 'package:note_vision/features/detection/domain/detected_staff.dart';
+import 'package:note_vision/features/detection/domain/detected_symbol.dart';
 import 'package:note_vision/features/editor/domain/editor_actions.dart';
-import 'package:note_vision/features/editor/model/editor_state.dart';
-import 'package:note_vision/features/editor/presentation/widgets/palette/music_symbol_palette.dart';
 import 'package:note_vision/features/editor/domain/model/musical_symbol.dart';
+import 'package:note_vision/features/editor/model/editor_state.dart';
+import 'package:note_vision/features/mapping/domain/internal/pitch_calculator.dart';
+import 'package:note_vision/features/editor/presentation/widgets/palette/music_symbol_palette.dart';
 
 class EditorShellArgs {
   const EditorShellArgs({required this.score, required this.initialState});
@@ -30,24 +37,159 @@ class EditorShellScreen extends StatefulWidget {
 
 class _EditorShellScreenState extends State<EditorShellScreen> {
   late EditorState _editorState;
+  final GlobalKey _notationDropKey = GlobalKey();
+  final PitchCalculator _pitchCalculator = const PitchCalculator();
+  final NotationLayoutCalculator _layoutCalculator = const NotationLayoutCalculator();
+  _PaletteDropCandidate? _paletteHoverCandidate;
 
   void _handleSymbolDrop(MusicalSymbol symbol, Offset globalPosition) {
-  // For now, just insert at the end of current measure as placeholder
-  _updateState((state) {
-    if (symbol.isRest) {
-      return state.insertRestAfterSelection();
-    } else {
-      return state.insertNoteAfterSelection();
+    final candidate = _resolveDropCandidate(globalPosition);
+    if (candidate == null) {
+      if (_paletteHoverCandidate != null) {
+        setState(() => _paletteHoverCandidate = null);
+      }
+      return;
     }
-  });
 
-  // Later (ticket 56): improve position-based insertion using globalPosition
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Dropped ${symbol.label} — position logic coming in ticket 56'),
-        duration: const Duration(seconds: 1),
+    final symbolToInsert = _scoreSymbolFromPalette(
+      paletteSymbol: symbol,
+      candidate: candidate,
+    );
+    if (symbolToInsert == null) return;
+
+    _updateState(
+      (state) => state.insertSymbolAtPosition(
+        measureIndex: candidate.measureIndex,
+        symbolIndex: candidate.insertIndex,
+        symbol: symbolToInsert,
       ),
     );
+    if (_paletteHoverCandidate != null) {
+      setState(() => _paletteHoverCandidate = null);
+    }
+  }
+
+  void _handleDragMove(Offset globalPosition) {
+    final candidate = _resolveDropCandidate(globalPosition);
+    if (candidate == _paletteHoverCandidate) return;
+    setState(() {
+      _paletteHoverCandidate = candidate;
+    });
+  }
+
+  _PaletteDropCandidate? _resolveDropCandidate(Offset globalPosition) {
+    final box = _notationDropKey.currentContext?.findRenderObject() as RenderBox?;
+    if (box == null) return null;
+    final local = box.globalToLocal(globalPosition);
+    final score = _editorState.score;
+    if (score.parts.isEmpty) return null;
+    final measures = score.parts.first.measures;
+    if (measures.isEmpty) return null;
+
+    final layout = _layoutCalculator.calculate(
+      measures: measures,
+      measuresPerRow: 4,
+      minMeasureWidth: 140,
+      rowHeight: 140,
+      padding: const EdgeInsets.all(16),
+    );
+    final measureTargets = ScoreNotationPainter.buildMeasureTargets(
+      measures: measures,
+      measuresPerRow: layout.measuresPerRow,
+      minMeasureWidth: 140,
+      rowHeight: 140,
+      padding: const EdgeInsets.all(16),
+      rowPrefixWidth: layout.rowPrefixWidth,
+    );
+    NotationMeasureTarget? target;
+    for (final candidate in measureTargets) {
+      if (candidate.measureRect.contains(local)) {
+        target = candidate;
+        break;
+      }
+    }
+    if (target == null) return null;
+    final insertIndex = _insertIndexForX(local.dx, target);
+    return _PaletteDropCandidate(
+      measureIndex: target.measureIndex,
+      insertIndex: insertIndex,
+      dropY: local.dy,
+      staffLineYs: target.lineYs,
+    );
+  }
+
+  int _insertIndexForX(double dropX, NotationMeasureTarget target) {
+    final centers = target.symbolCentersX;
+    if (centers.isEmpty) return 0;
+    if (dropX <= centers.first) return 0;
+    for (var index = 0; index < centers.length - 1; index++) {
+      final midpoint = (centers[index] + centers[index + 1]) / 2;
+      if (dropX < midpoint) return index + 1;
+    }
+    return centers.length;
+  }
+
+  ScoreSymbol? _scoreSymbolFromPalette({
+    required MusicalSymbol paletteSymbol,
+    required _PaletteDropCandidate candidate,
+  }) {
+    final spec = _durationForPaletteSymbol(paletteSymbol);
+    if (paletteSymbol.isRest) {
+      return Rest(duration: spec.$2, type: spec.$1);
+    }
+
+    final pitch = _pitchForDrop(candidate);
+    if (pitch == null) return null;
+    return Note(
+      step: pitch.$1,
+      octave: pitch.$2,
+      duration: spec.$2,
+      type: spec.$1,
+    );
+  }
+
+  (String, int) _durationForPaletteSymbol(MusicalSymbol symbol) {
+    switch (symbol) {
+      case MusicalSymbol.wholeNote:
+      case MusicalSymbol.wholeRest:
+        return ('whole', 4);
+      case MusicalSymbol.halfNote:
+      case MusicalSymbol.halfRest:
+        return ('half', 2);
+      case MusicalSymbol.eighthNote:
+        return ('eighth', 1);
+      case MusicalSymbol.quarterNote:
+      case MusicalSymbol.quarterRest:
+        return ('quarter', 1);
+    }
+  }
+
+  (String, int)? _pitchForDrop(_PaletteDropCandidate candidate) {
+    final lineYs = candidate.staffLineYs;
+    if (lineYs.length < 2) return null;
+    final sortedLineYs = [...lineYs]..sort();
+    final staff = DetectedStaff(
+      id: 'editor-drop-target',
+      topY: sortedLineYs.first,
+      bottomY: sortedLineYs.last,
+      lineYs: sortedLineYs,
+    );
+    final y = candidate.dropY;
+    final symbol = DetectedSymbol(
+      id: 'editor-drop-symbol',
+      type: 'notehead',
+      x: 0,
+      y: y,
+      width: 0,
+      height: 0,
+    );
+    final pitch = _pitchCalculator.calculate(
+      symbol: symbol,
+      staff: staff,
+      clef: const Clef(sign: 'G', line: 2),
+    );
+    if (pitch == null) return null;
+    return (pitch.step, pitch.octave);
   }
 
   @override
@@ -132,48 +274,60 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
             final isLandscape = constraints.maxWidth > constraints.maxHeight;
             final controlPanelWidth = (constraints.maxWidth * 0.32).clamp(280.0, 360.0) as double;
             final notationPanel = Container(
+              key: _notationDropKey,
               decoration: BoxDecoration(
                 color: AppColors.surface,
                 borderRadius: BorderRadius.circular(14),
                 border: Border.all(color: AppColors.border),
               ),
               child: DragTarget<MusicalSymbol>(
-              onWillAcceptWithDetails: (details) => true,
-              onAcceptWithDetails: (details) {
-                final symbol = details.data;
-                final globalPosition = details.offset;
-                _handleSymbolDrop(symbol, globalPosition);
-              },
-              builder: (context, candidateData, rejectedData) {
-                return SingleChildScrollView(
-                  child: Padding(
-                    padding: const EdgeInsets.all(8),
-                    child: ScoreNotationViewer(
-                      score: _editorState.score,
-                      selectedMeasureIndex: _editorState.selectedMeasureIndex,
-                      selectedSymbolIndex: _editorState.selectedSymbolIndex,
-                      onSymbolTap: (target) {
-                        if (target == null) {
-                          _updateState((state) => _clearSymbolSelection(state));
-                          return;
-                        }
-                        _onNotationSymbolTap(target.measureIndex, target.symbolIndex);
-                      },
-                      onSymbolReorder: (event) {
-                        _updateState(
-                          (state) => state.reorderSymbolWithinMeasure(
-                            measureIndex: event.measureIndex,
-                            fromSymbolIndex: event.fromSymbolIndex,
-                            toSymbolIndex: event.toSymbolIndex,
-                          ),
-                        );
-                      },
+                onWillAcceptWithDetails: (_) => true,
+                onMove: (details) => _handleDragMove(details.offset),
+                onLeave: (_) {
+                  if (_paletteHoverCandidate == null) return;
+                  setState(() => _paletteHoverCandidate = null);
+                },
+                onAcceptWithDetails: (details) {
+                  final symbol = details.data;
+                  final globalPosition = details.offset;
+                  _handleSymbolDrop(symbol, globalPosition);
+                },
+                builder: (context, candidateData, rejectedData) {
+                  return SingleChildScrollView(
+                    child: Padding(
+                      padding: const EdgeInsets.all(8),
+                      child: ScoreNotationViewer(
+                        score: _editorState.score,
+                        selectedMeasureIndex: _editorState.selectedMeasureIndex,
+                        selectedSymbolIndex: _editorState.selectedSymbolIndex,
+                        insertionIndicator: _paletteHoverCandidate == null
+                            ? null
+                            : NotationInsertionIndicator(
+                                measureIndex: _paletteHoverCandidate!.measureIndex,
+                                insertIndex: _paletteHoverCandidate!.insertIndex,
+                              ),
+                        onSymbolTap: (target) {
+                          if (target == null) {
+                            _updateState((state) => _clearSymbolSelection(state));
+                            return;
+                          }
+                          _onNotationSymbolTap(target.measureIndex, target.symbolIndex);
+                        },
+                        onSymbolReorder: (event) {
+                          _updateState(
+                            (state) => state.reorderSymbolWithinMeasure(
+                              measureIndex: event.measureIndex,
+                              fromSymbolIndex: event.fromSymbolIndex,
+                              toSymbolIndex: event.toSymbolIndex,
+                            ),
+                          );
+                        },
+                      ),
                     ),
-                  ),
-                );
-              },
-            )
-          );
+                  );
+                },
+              ),
+            );
 
 
             final statusStrip = _StatusStrip(
@@ -836,5 +990,46 @@ class _ControlButton extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+class _PaletteDropCandidate {
+  const _PaletteDropCandidate({
+    required this.measureIndex,
+    required this.insertIndex,
+    required this.dropY,
+    required this.staffLineYs,
+  });
+
+  final int measureIndex;
+  final int insertIndex;
+  final double dropY;
+  final List<double> staffLineYs;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is _PaletteDropCandidate &&
+        other.measureIndex == measureIndex &&
+        other.insertIndex == insertIndex &&
+        other.dropY == dropY &&
+        _listEquals(other.staffLineYs, staffLineYs);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        measureIndex,
+        insertIndex,
+        dropY,
+        Object.hashAll(staffLineYs),
+      );
+
+  static bool _listEquals(List<double> a, List<double> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
   }
 }

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -37,7 +37,7 @@ class EditorShellScreen extends StatefulWidget {
 
 class _EditorShellScreenState extends State<EditorShellScreen> {
   late EditorState _editorState;
-  final GlobalKey _notationDropKey = GlobalKey();
+  final GlobalKey _notationViewerKey = GlobalKey();
   final PitchCalculator _pitchCalculator = const PitchCalculator();
   final NotationLayoutCalculator _layoutCalculator = const NotationLayoutCalculator();
   _PaletteDropCandidate? _paletteHoverCandidate;
@@ -78,7 +78,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
   }
 
   _PaletteDropCandidate? _resolveDropCandidate(Offset globalPosition) {
-    final box = _notationDropKey.currentContext?.findRenderObject() as RenderBox?;
+    final box = _notationViewerKey.currentContext?.findRenderObject() as RenderBox?;
     if (box == null) return null;
     final local = box.globalToLocal(globalPosition);
     final score = _editorState.score;
@@ -274,7 +274,6 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
             final isLandscape = constraints.maxWidth > constraints.maxHeight;
             final controlPanelWidth = (constraints.maxWidth * 0.32).clamp(280.0, 360.0) as double;
             final notationPanel = Container(
-              key: _notationDropKey,
               decoration: BoxDecoration(
                 color: AppColors.surface,
                 borderRadius: BorderRadius.circular(14),
@@ -297,6 +296,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                     child: Padding(
                       padding: const EdgeInsets.all(8),
                       child: ScoreNotationViewer(
+                        key: _notationViewerKey,
                         score: _editorState.score,
                         selectedMeasureIndex: _editorState.selectedMeasureIndex,
                         selectedSymbolIndex: _editorState.selectedSymbolIndex,

--- a/lib/features/editor/presentation/widgets/palette/palette_item.dart
+++ b/lib/features/editor/presentation/widgets/palette/palette_item.dart
@@ -27,7 +27,7 @@ class PaletteItem extends StatelessWidget {
         opacity: 0.32,
         child: _buildSymbolContainer(symbol),
       ),
-      dragAnchorStrategy: childDragAnchorStrategy,
+      dragAnchorStrategy: pointerDragAnchorStrategy,
       child: _buildSymbolContainer(symbol),
     );
   }

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:note_vision/core/models/score.dart';
 import 'package:note_vision/core/widgets/score_notation_viewer.dart';
 import 'package:note_vision/core/widgets/score_notation/notation_layout.dart';
 import 'package:note_vision/core/widgets/score_notation/score_notation_painter.dart';
+import 'package:note_vision/features/editor/domain/model/musical_symbol.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
 import 'package:note_vision/features/editor/presentation/editor_shell_screen.dart';
 
@@ -212,6 +213,191 @@ void main() {
     expect(find.text('C4'), findsOneWidget);
   });
 
+  testWidgets('palette note drop inserts by x index and y pitch, and undo restores', (
+    tester,
+  ) async {
+    final score = Score(
+      id: 'score-drop-note',
+      title: 'Test Score',
+      composer: 'Composer',
+      parts: [
+        Part(
+          id: 'P1',
+          name: 'Part 1',
+          measures: [
+            Measure(
+              number: 1,
+              symbols: const [
+                Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+                Rest(duration: 1, type: 'quarter'),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final indicatorBefore = tester.widget<ScoreNotationViewer>(find.byType(ScoreNotationViewer));
+    expect(indicatorBefore.insertionIndicator, isNull);
+
+    final notationOrigin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    final dropOffset = notationOrigin +
+        _measureDropOffset(
+          score,
+          measureIndex: 0,
+          dropX: 66,
+          dropY: 76,
+        );
+    await _dragPaletteTo(
+      tester,
+      symbol: MusicalSymbol.quarterNote,
+      dropOffset: dropOffset,
+    );
+    await tester.pump();
+
+    final indicatorDuring = tester.widget<ScoreNotationViewer>(find.byType(ScoreNotationViewer));
+    expect(indicatorDuring.insertionIndicator, isNotNull);
+
+    await tester.pumpAndSettle();
+
+    final expectedAfterInsert = Score(
+      id: score.id,
+      title: score.title,
+      composer: score.composer,
+      parts: [
+        Part(
+          id: 'P1',
+          name: 'Part 1',
+          measures: [
+            Measure(
+              number: 1,
+              symbols: const [
+                Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+                Note(step: 'E', octave: 4, duration: 1, type: 'quarter'),
+                Rest(duration: 1, type: 'quarter'),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    final origin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    await tester.tapAt(
+      origin + _symbolCenterOffset(expectedAfterInsert, measureIndex: 0, symbolIndex: 1),
+    );
+    await tester.pump();
+    expect(find.text('Note'), findsOneWidget);
+    expect(find.text('E4'), findsOneWidget);
+
+    final undoButton = find.widgetWithText(OutlinedButton, 'Undo');
+    await tester.ensureVisible(undoButton);
+    await tester.tap(undoButton);
+    await tester.pumpAndSettle();
+
+    await tester.tapAt(origin + _symbolCenterOffset(score, measureIndex: 0, symbolIndex: 1));
+    await tester.pump();
+    expect(find.text('Rest'), findsOneWidget);
+  });
+
+  testWidgets('palette rest drop ignores y and inserts in empty measure at index 0', (
+    tester,
+  ) async {
+    final score = buildScore(withSymbols: false);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final notationOrigin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    await _dragPaletteTo(
+      tester,
+      symbol: MusicalSymbol.halfRest,
+      dropOffset: notationOrigin +
+          _measureDropOffset(
+            score,
+            measureIndex: 0,
+            dropX: 40,
+            dropY: 52,
+          ),
+    );
+    await tester.pumpAndSettle();
+
+    final expected = Score(
+      id: score.id,
+      title: score.title,
+      composer: score.composer,
+      parts: [
+        Part(
+          id: 'P1',
+          name: 'Part 1',
+          measures: [
+            Measure(
+              number: 1,
+              symbols: const [Rest(duration: 2, type: 'half')],
+            ),
+          ],
+        ),
+      ],
+    );
+    final origin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    await tester.tapAt(origin + _symbolCenterOffset(expected, measureIndex: 0, symbolIndex: 0));
+    await tester.pump();
+
+    expect(find.text('Rest'), findsOneWidget);
+    expect(find.text('—'), findsWidgets);
+    expect(find.text('half'), findsOneWidget);
+  });
+
+  testWidgets('dropping outside measure boundaries is ignored', (tester) async {
+    final score = buildScore();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final notationOrigin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    await _dragPaletteTo(
+      tester,
+      symbol: MusicalSymbol.quarterNote,
+      dropOffset: notationOrigin + const Offset(8, 8),
+    );
+    await tester.pumpAndSettle();
+
+    final origin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    await tester.tapAt(origin + _symbolCenterOffset(score, measureIndex: 0, symbolIndex: 1));
+    await tester.pump();
+
+    expect(find.text('Rest'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('landscape keeps controls beside notation without overlap', (
     tester,
   ) async {
@@ -239,6 +425,50 @@ void main() {
     expect(symbolLabelRect.left, greaterThan(notationRect.right));
     expect(tester.takeException(), isNull);
   });
+}
+
+Future<void> _dragPaletteTo(
+  WidgetTester tester, {
+  required MusicalSymbol symbol,
+  required Offset dropOffset,
+}) async {
+  final paletteFinder = find.bySemanticsLabel('${symbol.label} palette symbol');
+  expect(paletteFinder, findsOneWidget);
+  final start = tester.getCenter(paletteFinder);
+  final gesture = await tester.startGesture(start);
+  await tester.pump(kLongPressTimeout + const Duration(milliseconds: 80));
+  await gesture.moveTo(dropOffset);
+  await tester.pump();
+  await gesture.up();
+}
+
+Offset _measureDropOffset(
+  Score score, {
+  required int measureIndex,
+  required double dropX,
+  required double dropY,
+}) {
+  const measuresPerRow = 4;
+  const minMeasureWidth = 140.0;
+  const rowHeight = 140.0;
+  const padding = EdgeInsets.all(16);
+  final measures = score.parts.first.measures;
+  final layout = const NotationLayoutCalculator().calculate(
+    measures: measures,
+    measuresPerRow: measuresPerRow,
+    minMeasureWidth: minMeasureWidth,
+    rowHeight: rowHeight,
+    padding: padding,
+  );
+  final target = ScoreNotationPainter.buildMeasureTargets(
+    measures: measures,
+    measuresPerRow: layout.measuresPerRow,
+    minMeasureWidth: minMeasureWidth,
+    rowHeight: rowHeight,
+    padding: padding,
+    rowPrefixWidth: layout.rowPrefixWidth,
+  ).firstWhere((entry) => entry.measureIndex == measureIndex);
+  return target.measureRect.topLeft + Offset(dropX, dropY);
 }
 
 Offset _symbolCenterOffset(

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -253,13 +253,8 @@ void main() {
     expect(indicatorBefore.insertionIndicator, isNull);
 
     final notationOrigin = tester.getTopLeft(find.byType(ScoreNotationViewer));
-    final dropOffset = notationOrigin +
-        _measureDropOffset(
-          score,
-          measureIndex: 0,
-          dropX: 66,
-          dropY: 76,
-        );
+    final target = _measureTarget(score, measureIndex: 0);
+    final dropOffset = notationOrigin + Offset(66, target.lineYs.last);
     await _dragPaletteTo(
       tester,
       symbol: MusicalSymbol.quarterNote,
@@ -329,16 +324,11 @@ void main() {
     await tester.pumpAndSettle();
 
     final notationOrigin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    final target = _measureTarget(score, measureIndex: 0);
     await _dragPaletteTo(
       tester,
       symbol: MusicalSymbol.halfRest,
-      dropOffset: notationOrigin +
-          _measureDropOffset(
-            score,
-            measureIndex: 0,
-            dropX: 40,
-            dropY: 52,
-          ),
+      dropOffset: notationOrigin + Offset(40, target.lineYs.first),
     );
     await tester.pumpAndSettle();
 
@@ -442,12 +432,7 @@ Future<void> _dragPaletteTo(
   await gesture.up();
 }
 
-Offset _measureDropOffset(
-  Score score, {
-  required int measureIndex,
-  required double dropX,
-  required double dropY,
-}) {
+NotationMeasureTarget _measureTarget(Score score, {required int measureIndex}) {
   const measuresPerRow = 4;
   const minMeasureWidth = 140.0;
   const rowHeight = 140.0;
@@ -468,7 +453,7 @@ Offset _measureDropOffset(
     padding: padding,
     rowPrefixWidth: layout.rowPrefixWidth,
   ).firstWhere((entry) => entry.measureIndex == measureIndex);
-  return target.measureRect.topLeft + Offset(dropX, dropY);
+  return target;
 }
 
 Offset _symbolCenterOffset(

--- a/test/features/editor/presentation/widgets/palette/music_symbol_palette_test.dart
+++ b/test/features/editor/presentation/widgets/palette/music_symbol_palette_test.dart
@@ -55,6 +55,7 @@ void main() {
     final draggable = tester.widget<LongPressDraggable<MusicalSymbol>>(
       find.byType(LongPressDraggable<MusicalSymbol>),
     );
+    expect(draggable.dragAnchorStrategy, pointerDragAnchorStrategy);
     final feedbackMaterial = draggable.feedback as Material;
     final feedbackTransform = feedbackMaterial.child as Transform;
     expect(feedbackTransform.transform.getMaxScaleOnAxis(), closeTo(1.5, 0.001));


### PR DESCRIPTION
### Motivation
- Enable dragging symbols from the palette onto the notation and inserting them at a specific measure/index with a visual cue. 
- Provide utilities to compute measure hit-targets and symbol center X positions to support accurate insert/hover behavior. 
- Expose an editor action to insert a symbol at an arbitrary measure/symbol index for use by the drag-and-drop flow.

### Description
- Added an `insertionIndicator` property to `ScoreNotationPainter` and `ScoreNotationViewer` and draw a vertical blue insertion line in `_drawRow` when present. 
- Implemented `ScoreNotationPainter.buildMeasureTargets`, `_symbolCentersX`, and `_insertionLineX` to compute measure rectangles, staff line Ys, symbol center Xs and insertion X positions, and added `NotationMeasureTarget` and `NotationInsertionIndicator` classes. 
- Updated `shouldRepaint` to include `insertionIndicator` changes. 
- Added `EditorActions.insertSymbolAtPosition` to insert a `ScoreSymbol` at a specified measure and symbol index and update selection. 
- Implemented drag/drop handling in the editor UI: `EditorShellScreen` now resolves drop candidates with `_resolveDropCandidate`, computes insertion index with `_insertIndexForX`, maps palette symbols to `Note`/`Rest` with `_scoreSymbolFromPalette`, uses `PitchCalculator` to derive pitch from drop Y, and inserts via `insertSymbolAtPosition`. 
- Added hover state `_paletteHoverCandidate` and wire `DragTarget` callbacks (`onMove`, `onLeave`, `onAcceptWithDetails`) to show the insertion indicator while dragging. 
- Added `_PaletteDropCandidate` helper to represent the current drop candidate. 
- Updated `ScoreNotationViewer` usage in the editor to pass the hover-driven `NotationInsertionIndicator` so the painter can render the insertion line. 
- Extended tests and test helpers in `test/features/editor/presentation/editor_shell_screen_test.dart` to exercise palette drag-to-insert behavior and boundary cases.

### Testing
- Ran widget tests in `test/features/editor/presentation/editor_shell_screen_test.dart` which include new drag/drop scenarios for note and rest insertion and boundary checks, and they passed. 
- Ran the existing editor widget tests (selection, reorder, layout/landscape) after changes, and they passed. 
- No failing automated tests were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdfb4bdba8832080a6aa920c46f495)