### PR TITLE
Add drag-and-drop insertion support and visual insertion indicator in notation viewer

### DIFF
--- a/lib/core/widgets/score_notation/score_notation_painter.dart
+++ b/lib/core/widgets/score_notation/score_notation_painter.dart
@@ -21,6 +21,7 @@ class ScoreNotationPainter extends CustomPainter {
     this.selectedMeasureIndex,
     this.selectedSymbolIndex,
     this.dragFeedback,
+    this.insertionFeedback,
   });
 
   final List<Measure> measures;
@@ -32,6 +33,7 @@ class ScoreNotationPainter extends CustomPainter {
   final int? selectedMeasureIndex;
   final int? selectedSymbolIndex;
   final NotationDragFeedback? dragFeedback;
+  final NotationInsertionFeedback? insertionFeedback;
 
   static const double staffLineSpacing = 12;
   static const double tapTargetSize = 24;
@@ -145,6 +147,55 @@ class ScoreNotationPainter extends CustomPainter {
         }
       }
     }
+    return targets;
+  }
+
+  static List<NotationMeasureTarget> buildMeasureTargets({
+    required List<Measure> measures,
+    required int measuresPerRow,
+    required double minMeasureWidth,
+    required double rowHeight,
+    required EdgeInsets padding,
+    required double rowPrefixWidth,
+  }) {
+    final rows = _buildRowMetricsStatic(
+      measures: measures,
+      measuresPerRow: measuresPerRow,
+      rowHeight: rowHeight,
+      padding: padding,
+      rowPrefixWidth: rowPrefixWidth,
+      minMeasureWidth: minMeasureWidth,
+    );
+    final targets = <NotationMeasureTarget>[];
+
+    for (final row in rows) {
+      for (var measureInRow = 0; measureInRow < row.measures.length; measureInRow++) {
+        final measureStartX = row.contentStartX + (measureInRow * minMeasureWidth);
+        final measureEndX = measureStartX + minMeasureWidth;
+        final lineYs = List<double>.generate(
+          5,
+          (index) => row.staffTop + (index * staffLineSpacing),
+          growable: false,
+        );
+        targets.add(
+          NotationMeasureTarget(
+            measureIndex: row.globalStartMeasureIndex + measureInRow,
+            dropRect: Rect.fromLTRB(
+              measureStartX,
+              row.staffTop - 32,
+              measureEndX,
+              row.staffBottom + 32,
+            ),
+            measureStartX: measureStartX,
+            measureEndX: measureEndX,
+            staffTop: row.staffTop,
+            staffBottom: row.staffBottom,
+            lineYs: lineYs,
+          ),
+        );
+      }
+    }
+
     return targets;
   }
 
@@ -276,8 +327,6 @@ class ScoreNotationPainter extends CustomPainter {
     required double staffTop,
     required double staffBottom,
   }) {
-    if (measure.symbols.isEmpty) return;
-
     final symbolCount = measure.symbols.length;
     const innerPadding = 16.0;
     final drawableWidth = math.max(
@@ -303,6 +352,11 @@ class ScoreNotationPainter extends CustomPainter {
             measureEndX - innerPadding,
           )
         : 0.0;
+    final insertion = insertionFeedback;
+    final showInsertionIndicator = insertion != null &&
+        insertion.measureIndex == absoluteMeasureIndex &&
+        insertion.insertIndex >= 0 &&
+        insertion.insertIndex <= symbolCount;
 
     for (var i = 0; i < symbolCount; i++) {
       if (activeDrag != null && i == activeDrag.draggedSymbolIndex) {
@@ -344,6 +398,18 @@ class ScoreNotationPainter extends CustomPainter {
       }
     }
 
+    if (showInsertionIndicator && insertion != null) {
+      final insertionX = _insertionXForIndex(
+        insertIndex: insertion.insertIndex,
+        symbolCount: symbolCount,
+        measureStartX: measureStartX,
+        measureEndX: measureEndX,
+        innerPadding: innerPadding,
+        drawableWidth: drawableWidth,
+      );
+      _drawInsertionIndicator(canvas, insertionX, staffTop, staffBottom);
+    }
+
     if (!hasDragInMeasure || draggedSymbol == null) return;
 
     final dragY = _symbolCenterY(draggedSymbol, staffTop, staffBottom) - 8;
@@ -360,6 +426,48 @@ class ScoreNotationPainter extends CustomPainter {
       _drawSelectionHighlight(canvas, Offset(clampedDragX, dragY), radius: 16);
       _drawRest(canvas, draggedSymbol, x: clampedDragX, staffTop: staffTop - 8);
     }
+
+  }
+
+  double _insertionXForIndex({
+    required int insertIndex,
+    required int symbolCount,
+    required double measureStartX,
+    required double measureEndX,
+    required double innerPadding,
+    required double drawableWidth,
+  }) {
+    final leftBound = measureStartX + innerPadding;
+    final rightBound = measureEndX - innerPadding;
+
+    if (symbolCount <= 0) {
+      return (leftBound + rightBound) / 2;
+    }
+
+    final centers = List<double>.generate(symbolCount, (index) {
+      final progress = (index + 1) / (symbolCount + 1);
+      return measureStartX + innerPadding + (drawableWidth * progress);
+    }, growable: false);
+
+    if (insertIndex <= 0) return (leftBound + centers.first) / 2;
+    if (insertIndex >= symbolCount) return (centers.last + rightBound) / 2;
+    return (centers[insertIndex - 1] + centers[insertIndex]) / 2;
+  }
+
+  void _drawInsertionIndicator(
+    Canvas canvas,
+    double x,
+    double staffTop,
+    double staffBottom,
+  ) {
+    final paint = Paint()
+      ..color = const Color(0xFF2563EB)
+      ..strokeWidth = 2;
+    canvas.drawLine(
+      Offset(x, staffTop - 8),
+      Offset(x, staffBottom + 8),
+      paint,
+    );
   }
 
   void _drawSelectionHighlight(Canvas canvas, Offset center, {double radius = 14}) {
@@ -652,7 +760,8 @@ class ScoreNotationPainter extends CustomPainter {
         oldDelegate.rowPrefixWidth != rowPrefixWidth ||
         oldDelegate.selectedMeasureIndex != selectedMeasureIndex ||
         oldDelegate.selectedSymbolIndex != selectedSymbolIndex ||
-        oldDelegate.dragFeedback != dragFeedback;
+        oldDelegate.dragFeedback != dragFeedback ||
+        oldDelegate.insertionFeedback != insertionFeedback;
   }
 }
 
@@ -699,6 +808,47 @@ class NotationDragFeedback {
       draggedSymbolIndex.hashCode ^
       targetSymbolIndex.hashCode ^
       dragX.hashCode;
+}
+
+class NotationInsertionFeedback {
+  const NotationInsertionFeedback({
+    required this.measureIndex,
+    required this.insertIndex,
+  });
+
+  final int measureIndex;
+  final int insertIndex;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NotationInsertionFeedback &&
+          runtimeType == other.runtimeType &&
+          measureIndex == other.measureIndex &&
+          insertIndex == other.insertIndex;
+
+  @override
+  int get hashCode => Object.hash(measureIndex, insertIndex);
+}
+
+class NotationMeasureTarget {
+  const NotationMeasureTarget({
+    required this.measureIndex,
+    required this.dropRect,
+    required this.measureStartX,
+    required this.measureEndX,
+    required this.staffTop,
+    required this.staffBottom,
+    required this.lineYs,
+  });
+
+  final int measureIndex;
+  final Rect dropRect;
+  final double measureStartX;
+  final double measureEndX;
+  final double staffTop;
+  final double staffBottom;
+  final List<double> lineYs;
 }
 
 class _RowMetrics {

--- a/lib/core/widgets/score_notation/score_notation_painter.dart
+++ b/lib/core/widgets/score_notation/score_notation_painter.dart
@@ -398,9 +398,9 @@ class ScoreNotationPainter extends CustomPainter {
       }
     }
 
-    if (showInsertionIndicator && insertion != null) {
+    if (showInsertionIndicator) {
       final insertionX = _insertionXForIndex(
-        insertIndex: insertion.insertIndex,
+        insertIndex: insertion!.insertIndex,
         symbolCount: symbolCount,
         measureStartX: measureStartX,
         measureEndX: measureEndX,

--- a/lib/core/widgets/score_notation_viewer.dart
+++ b/lib/core/widgets/score_notation_viewer.dart
@@ -23,6 +23,7 @@ class ScoreNotationViewer extends StatefulWidget {
     this.selectedSymbolIndex,
     this.onSymbolTap,
     this.onSymbolReorder,
+    this.insertionFeedback,
   });
 
   final Score? score;
@@ -35,6 +36,7 @@ class ScoreNotationViewer extends StatefulWidget {
   final int? selectedSymbolIndex;
   final ValueChanged<NotationSymbolTarget?>? onSymbolTap;
   final ValueChanged<NotationSymbolReorder>? onSymbolReorder;
+  final NotationInsertionFeedback? insertionFeedback;
 
   @override
   State<ScoreNotationViewer> createState() => _ScoreNotationViewerState();
@@ -117,6 +119,7 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
                 targetSymbolIndex: _dragSession!.toSymbolIndex,
                 dragX: _dragSession!.dragPosition.dx,
               ),
+        insertionFeedback: widget.insertionFeedback,
       ),
     );
   }

--- a/lib/core/widgets/score_notation_viewer.dart
+++ b/lib/core/widgets/score_notation_viewer.dart
@@ -24,6 +24,7 @@ class ScoreNotationViewer extends StatefulWidget {
     this.onSymbolTap,
     this.onSymbolReorder,
     this.insertionFeedback,
+    this.onHorizontalScrollOffsetChanged,
   });
 
   final Score? score;
@@ -37,6 +38,7 @@ class ScoreNotationViewer extends StatefulWidget {
   final ValueChanged<NotationSymbolTarget?>? onSymbolTap;
   final ValueChanged<NotationSymbolReorder>? onSymbolReorder;
   final NotationInsertionFeedback? insertionFeedback;
+  final ValueChanged<double>? onHorizontalScrollOffsetChanged;
 
   @override
   State<ScoreNotationViewer> createState() => _ScoreNotationViewerState();
@@ -49,9 +51,20 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
   _NotationDragSession? _dragSession;
 
   @override
+  void initState() {
+    super.initState();
+    _horizontalController.addListener(_notifyHorizontalOffset);
+  }
+
+  @override
   void dispose() {
+    _horizontalController.removeListener(_notifyHorizontalOffset);
     _horizontalController.dispose();
     super.dispose();
+  }
+
+  void _notifyHorizontalOffset() {
+    widget.onHorizontalScrollOffsetChanged?.call(_horizontalController.offset);
   }
 
   @override

--- a/lib/features/editor/domain/editor_actions.dart
+++ b/lib/features/editor/domain/editor_actions.dart
@@ -133,6 +133,29 @@ extension EditorActions on EditorState {
 
   EditorState applyRedo() => redo();
 
+  EditorState insertSymbolAt({
+    required int partIndex,
+    required int measureIndex,
+    required int symbolIndex,
+    required ScoreSymbol symbol,
+  }) {
+    final nextScore = score.insertSymbolAt(
+      partIndex,
+      measureIndex,
+      symbolIndex,
+      symbol,
+    );
+    if (identical(nextScore, score)) return this;
+
+    return applyEdit(
+      score: nextScore,
+      selectedPartIndex: partIndex,
+      selectedMeasureIndex: measureIndex,
+      selectedSymbolIndex: symbolIndex,
+      selectedSymbol: symbol,
+    );
+  }
+
   EditorState moveSelectedSymbolToMeasureOffset(int offset) {
     if (!hasSelection || offset == 0) return this;
 

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -924,13 +924,13 @@ class _InsertDropdown extends StatelessWidget {
                 }
               : null,
           icon: Icon(icon, size: 16),
-          label: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text('Insert $label'),
-              const SizedBox(width: 4),
-              const Icon(Icons.arrow_drop_down_rounded, size: 18),
-            ],
+          label: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(
+              'Insert $label',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
           style: OutlinedButton.styleFrom(
             backgroundColor: enabled ? AppColors.surface : AppColors.surfaceAlt,
@@ -938,7 +938,7 @@ class _InsertDropdown extends StatelessWidget {
             side: BorderSide(
               color: enabled ? AppColors.accent.withValues(alpha: 0.6) : AppColors.border,
             ),
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
           ),
         );
       },

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -2,13 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:note_vision/core/models/note.dart';
 import 'package:note_vision/core/models/rest.dart';
 import 'package:note_vision/core/models/score.dart';
+import 'package:note_vision/core/models/score_symbol.dart';
 import 'package:note_vision/core/theme/app_theme.dart';
 import 'package:note_vision/core/theme/responsive_layout.dart';
+import 'package:note_vision/core/widgets/score_notation/notation_layout.dart';
+import 'package:note_vision/core/widgets/score_notation/score_notation_painter.dart';
 import 'package:note_vision/core/widgets/score_notation_viewer.dart';
+import 'package:note_vision/features/detection/domain/detected_staff.dart';
+import 'package:note_vision/features/detection/domain/detected_symbol.dart';
 import 'package:note_vision/features/editor/domain/editor_actions.dart';
+import 'package:note_vision/features/editor/domain/editor_actions.dart' as editor_actions;
 import 'package:note_vision/features/editor/model/editor_state.dart';
 import 'package:note_vision/features/editor/presentation/widgets/palette/music_symbol_palette.dart';
 import 'package:note_vision/features/editor/domain/model/musical_symbol.dart';
+import 'package:note_vision/features/mapping/domain/internal/pitch_calculator.dart';
+import 'package:note_vision/features/mapping/domain/internal/mapping_types.dart';
+import 'package:note_vision/core/models/clef.dart';
 
 class EditorShellArgs {
   const EditorShellArgs({required this.score, required this.initialState});
@@ -29,25 +38,187 @@ class EditorShellScreen extends StatefulWidget {
 }
 
 class _EditorShellScreenState extends State<EditorShellScreen> {
+  static const _viewerMeasuresPerRow = 4;
+  static const _viewerMinMeasureWidth = 140.0;
+  static const _viewerRowHeight = 140.0;
+  static const _viewerPadding = EdgeInsets.all(16);
+
+  final GlobalKey _notationViewerKey = GlobalKey();
+  final NotationLayoutCalculator _notationLayoutCalculator =
+      const NotationLayoutCalculator();
+  final PitchCalculator _pitchCalculator = const PitchCalculator();
   late EditorState _editorState;
+  NotationInsertionFeedback? _dropInsertionFeedback;
 
   void _handleSymbolDrop(MusicalSymbol symbol, Offset globalPosition) {
-  // For now, just insert at the end of current measure as placeholder
-  _updateState((state) {
-    if (symbol.isRest) {
-      return state.insertRestAfterSelection();
-    } else {
-      return state.insertNoteAfterSelection();
+    final insertion = _resolveInsertionTarget(globalPosition);
+    if (insertion == null) {
+      _setDropInsertionFeedback(null);
+      return;
     }
-  });
 
-  // Later (ticket 56): improve position-based insertion using globalPosition
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Dropped ${symbol.label} — position logic coming in ticket 56'),
-        duration: const Duration(seconds: 1),
+    final droppedSymbol = _toDroppedSymbol(
+      symbol: symbol,
+      localY: insertion.localPosition.dy,
+      lineYs: insertion.measureTarget.lineYs,
+    );
+    if (droppedSymbol == null) {
+      _setDropInsertionFeedback(null);
+      return;
+    }
+
+    _updateState(
+      (state) => state.insertSymbolAt(
+        partIndex: 0,
+        measureIndex: insertion.measureTarget.measureIndex,
+        symbolIndex: insertion.insertIndex,
+        symbol: droppedSymbol,
       ),
     );
+    _setDropInsertionFeedback(null);
+  }
+
+  void _handleDragHover(Offset globalPosition) {
+    final insertion = _resolveInsertionTarget(globalPosition);
+    final feedback = insertion == null
+        ? null
+        : NotationInsertionFeedback(
+            measureIndex: insertion.measureTarget.measureIndex,
+            insertIndex: insertion.insertIndex,
+          );
+    _setDropInsertionFeedback(feedback);
+  }
+
+  void _setDropInsertionFeedback(NotationInsertionFeedback? feedback) {
+    if (_dropInsertionFeedback == feedback) return;
+    setState(() {
+      _dropInsertionFeedback = feedback;
+    });
+  }
+
+  _DropInsertionTarget? _resolveInsertionTarget(Offset globalPosition) {
+    final viewerContext = _notationViewerKey.currentContext;
+    final renderObject = viewerContext?.findRenderObject();
+    if (renderObject is! RenderBox) return null;
+
+    final localPosition = renderObject.globalToLocal(globalPosition);
+    final part = _editorState.score.parts.isEmpty ? null : _editorState.score.parts.first;
+    final measures = part?.measures ?? const [];
+    if (measures.isEmpty) return null;
+
+    final layout = _notationLayoutCalculator.calculate(
+      measures: measures,
+      measuresPerRow: _viewerMeasuresPerRow,
+      minMeasureWidth: _viewerMinMeasureWidth,
+      rowHeight: _viewerRowHeight,
+      padding: _viewerPadding,
+    );
+
+    NotationMeasureTarget? measureTarget;
+    for (final entry in ScoreNotationPainter.buildMeasureTargets(
+      measures: measures,
+      measuresPerRow: layout.measuresPerRow,
+      minMeasureWidth: _viewerMinMeasureWidth,
+      rowHeight: _viewerRowHeight,
+      padding: _viewerPadding,
+      rowPrefixWidth: layout.rowPrefixWidth,
+    )) {
+      if (entry.dropRect.contains(localPosition)) {
+        measureTarget = entry;
+        break;
+      }
+    }
+
+    if (measureTarget == null) return null;
+
+    final symbolTargets = ScoreNotationPainter.buildSymbolTargets(
+      measures: measures,
+      measuresPerRow: layout.measuresPerRow,
+      minMeasureWidth: _viewerMinMeasureWidth,
+      rowHeight: _viewerRowHeight,
+      padding: _viewerPadding,
+      rowPrefixWidth: layout.rowPrefixWidth,
+    ).where((entry) => entry.measureIndex == measureTarget.measureIndex).toList()
+      ..sort((a, b) => a.center.dx.compareTo(b.center.dx));
+
+    final insertIndex = _insertionIndexForX(localPosition.dx, symbolTargets);
+
+    return _DropInsertionTarget(
+      measureTarget: measureTarget,
+      insertIndex: insertIndex,
+      localPosition: localPosition,
+    );
+  }
+
+  int _insertionIndexForX(double dropX, List<NotationSymbolTarget> targets) {
+    if (targets.isEmpty) return 0;
+    for (var i = 0; i < targets.length; i++) {
+      if (dropX < targets[i].center.dx) {
+        return i;
+      }
+    }
+    return targets.length;
+  }
+
+  Pitch? _pitchForY(double y, List<double> lineYs) {
+    if (lineYs.length < 2) return null;
+    final sorted = [...lineYs]..sort();
+    final staff = DetectedStaff(
+      id: 'editor-drop',
+      topY: sorted.first,
+      bottomY: sorted.last,
+      lineYs: sorted,
+    );
+    final symbol = DetectedSymbol(
+      id: 'editor-drop-symbol',
+      type: 'noteheadBlack',
+      x: 0,
+      y: y,
+      width: 0,
+      height: 0,
+    );
+    return _pitchCalculator.calculate(
+      symbol: symbol,
+      staff: staff,
+      clef: const Clef(sign: 'G', line: 2),
+    );
+  }
+
+  ScoreSymbol? _toDroppedSymbol({
+    required MusicalSymbol symbol,
+    required double localY,
+    required List<double> lineYs,
+  }) {
+    if (symbol.isRest) {
+      final spec = _durationFor(symbol);
+      return Rest(duration: spec.divisions, type: spec.type);
+    }
+
+    final pitch = _pitchForY(localY, lineYs);
+    if (pitch == null) return null;
+    final spec = _durationFor(symbol);
+    return Note(
+      step: pitch.step,
+      octave: pitch.octave,
+      duration: spec.divisions,
+      type: spec.type,
+    );
+  }
+
+  editor_actions.DurationSpec _durationFor(MusicalSymbol symbol) {
+    switch (symbol) {
+      case MusicalSymbol.wholeNote:
+      case MusicalSymbol.wholeRest:
+        return wholeDuration;
+      case MusicalSymbol.halfNote:
+      case MusicalSymbol.halfRest:
+        return halfDuration;
+      case MusicalSymbol.eighthNote:
+        return eighthDuration;
+      case MusicalSymbol.quarterNote:
+      case MusicalSymbol.quarterRest:
+        return quarterDuration;
+    }
   }
 
   @override
@@ -138,7 +309,12 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                 border: Border.all(color: AppColors.border),
               ),
               child: DragTarget<MusicalSymbol>(
-              onWillAcceptWithDetails: (details) => true,
+              onWillAcceptWithDetails: (details) {
+                _handleDragHover(details.offset);
+                return true;
+              },
+              onMove: (details) => _handleDragHover(details.offset),
+              onLeave: (_) => _setDropInsertionFeedback(null),
               onAcceptWithDetails: (details) {
                 final symbol = details.data;
                 final globalPosition = details.offset;
@@ -149,9 +325,11 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                   child: Padding(
                     padding: const EdgeInsets.all(8),
                     child: ScoreNotationViewer(
+                      key: _notationViewerKey,
                       score: _editorState.score,
                       selectedMeasureIndex: _editorState.selectedMeasureIndex,
                       selectedSymbolIndex: _editorState.selectedSymbolIndex,
+                      insertionFeedback: _dropInsertionFeedback,
                       onSymbolTap: (target) {
                         if (target == null) {
                           _updateState((state) => _clearSymbolSelection(state));
@@ -837,4 +1015,16 @@ class _ControlButton extends StatelessWidget {
       ),
     );
   }
+}
+
+class _DropInsertionTarget {
+  const _DropInsertionTarget({
+    required this.measureTarget,
+    required this.insertIndex,
+    required this.localPosition,
+  });
+
+  final NotationMeasureTarget measureTarget;
+  final int insertIndex;
+  final Offset localPosition;
 }

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -815,12 +815,12 @@ class _EditorActionBar extends StatelessWidget {
             children: [
               _ControlButton(
                 icon: Icons.arrow_upward_rounded,
-                label: 'Up',
+                label: 'Move Up',
                 onPressed: hasSelection ? onMoveUp : null,
               ),
               _ControlButton(
                 icon: Icons.arrow_downward_rounded,
-                label: 'Down',
+                label: 'Move Down',
                 onPressed: hasSelection ? onMoveDown : null,
               ),
               _ControlButton(

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -132,6 +132,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
     }
 
     if (measureTarget == null) return null;
+    final resolvedMeasureTarget = measureTarget;
 
     final symbolTargets = ScoreNotationPainter.buildSymbolTargets(
       measures: measures,
@@ -140,13 +141,13 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
       rowHeight: _viewerRowHeight,
       padding: _viewerPadding,
       rowPrefixWidth: layout.rowPrefixWidth,
-    ).where((entry) => entry.measureIndex == measureTarget.measureIndex).toList()
+    ).where((entry) => entry.measureIndex == resolvedMeasureTarget.measureIndex).toList()
       ..sort((a, b) => a.center.dx.compareTo(b.center.dx));
 
     final insertIndex = _insertionIndexForX(localPosition.dx, symbolTargets);
 
     return _DropInsertionTarget(
-      measureTarget: measureTarget,
+      measureTarget: resolvedMeasureTarget,
       insertIndex: insertIndex,
       localPosition: localPosition,
     );
@@ -323,7 +324,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
           builder: (context, constraints) {
             final horizontalPadding = ResponsiveLayout.horizontalPadding(constraints.maxWidth);
             final isLandscape = constraints.maxWidth > constraints.maxHeight;
-            final controlPanelWidth = (constraints.maxWidth * 0.32).clamp(280.0, 360.0) as double;
+            final controlPanelWidth = (constraints.maxWidth * 0.32).clamp(280.0, 360.0);
             final notationPanel = Container(
               decoration: BoxDecoration(
                 color: AppColors.surface,

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -49,6 +49,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
   final PitchCalculator _pitchCalculator = const PitchCalculator();
   late EditorState _editorState;
   NotationInsertionFeedback? _dropInsertionFeedback;
+  double _notationHorizontalScrollOffset = 0;
 
   void _handleSymbolDrop(MusicalSymbol symbol, Offset globalPosition) {
     final insertion = _resolveInsertionTarget(globalPosition);
@@ -101,7 +102,8 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
     final renderObject = viewerContext?.findRenderObject();
     if (renderObject is! RenderBox) return null;
 
-    final localPosition = renderObject.globalToLocal(globalPosition);
+    final localPosition =
+        renderObject.globalToLocal(globalPosition).translate(_notationHorizontalScrollOffset, 0);
     final part = _editorState.score.parts.isEmpty ? null : _editorState.score.parts.first;
     final measures = part?.measures ?? const [];
     if (measures.isEmpty) return null;
@@ -196,13 +198,33 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
 
     final pitch = _pitchForY(localY, lineYs);
     if (pitch == null) return null;
+    final clampedPitch = _clampToDemoTrebleRange(pitch);
     final spec = _durationFor(symbol);
     return Note(
-      step: pitch.step,
-      octave: pitch.octave,
+      step: clampedPitch.step,
+      octave: clampedPitch.octave,
       duration: spec.divisions,
       type: spec.type,
     );
+  }
+
+  Pitch _clampToDemoTrebleRange(Pitch pitch) {
+    const minPitch = Pitch(step: 'C', octave: 4);
+    const maxPitch = Pitch(step: 'G', octave: 5);
+    if (_comparePitch(pitch, minPitch) < 0) return minPitch;
+    if (_comparePitch(pitch, maxPitch) > 0) return maxPitch;
+    return pitch;
+  }
+
+  int _comparePitch(Pitch left, Pitch right) {
+    const steps = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+    final leftIndex = steps.indexOf(left.step.toUpperCase());
+    final rightIndex = steps.indexOf(right.step.toUpperCase());
+    final normalizedLeft = leftIndex < 0 ? 0 : leftIndex;
+    final normalizedRight = rightIndex < 0 ? 0 : rightIndex;
+    final leftAbsolute = (left.octave * steps.length) + normalizedLeft;
+    final rightAbsolute = (right.octave * steps.length) + normalizedRight;
+    return leftAbsolute.compareTo(rightAbsolute);
   }
 
   editor_actions.DurationSpec _durationFor(MusicalSymbol symbol) {
@@ -330,6 +352,9 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                       selectedMeasureIndex: _editorState.selectedMeasureIndex,
                       selectedSymbolIndex: _editorState.selectedSymbolIndex,
                       insertionFeedback: _dropInsertionFeedback,
+                      onHorizontalScrollOffsetChanged: (offset) {
+                        _notationHorizontalScrollOffset = offset;
+                      },
                       onSymbolTap: (target) {
                         if (target == null) {
                           _updateState((state) => _clearSymbolSelection(state));

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -316,6 +316,46 @@ void main() {
     expect(find.text('None'), findsOneWidget);
   });
 
+  testWidgets('palette note drop pitch clamps to C4-G5 demo range', (tester) async {
+    final score = buildScore(withSymbols: false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+
+    final origin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    final target = _measureTargetOffset(score, measureIndex: 0);
+
+    final highDrop = origin + Offset(target.measureCenterX, target.lineYs.first - 260);
+    var dragGesture = await tester.startGesture(
+      tester.getCenter(find.bySemanticsLabel('Quarter palette symbol')),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 120));
+    await dragGesture.moveTo(highDrop);
+    await tester.pump();
+    await dragGesture.up();
+    await tester.pumpAndSettle();
+    expect(find.text('G5'), findsOneWidget);
+
+    final lowDrop = origin + Offset(target.measureCenterX, target.lineYs.last + 260);
+    dragGesture = await tester.startGesture(
+      tester.getCenter(find.bySemanticsLabel('Quarter palette symbol')),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 120));
+    await dragGesture.moveTo(lowDrop);
+    await tester.pump();
+    await dragGesture.up();
+    await tester.pumpAndSettle();
+    expect(find.text('C4'), findsOneWidget);
+  });
+
   testWidgets('landscape keeps controls beside notation without overlap', (
     tester,
   ) async {

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -212,6 +212,110 @@ void main() {
     expect(find.text('C4'), findsOneWidget);
   });
 
+  testWidgets('palette drop inserts note by x index and y pitch', (tester) async {
+    final score = Score(
+      id: 'score-drop-note',
+      title: 'Drop Note',
+      composer: 'Composer',
+      parts: [
+        Part(
+          id: 'P1',
+          name: 'Part 1',
+          measures: [
+            Measure(
+              number: 1,
+              symbols: const [
+                Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+                Note(step: 'G', octave: 4, duration: 1, type: 'quarter'),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+
+    final origin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    final target = _measureTargetOffset(score, measureIndex: 0);
+    final symbolA = _symbolCenterOffset(score, measureIndex: 0, symbolIndex: 0);
+    final symbolB = _symbolCenterOffset(score, measureIndex: 0, symbolIndex: 1);
+    final dropX = (symbolA.dx + symbolB.dx) / 2;
+    final dropY = target.lineYs.last;
+    final dropPoint = origin + Offset(dropX, dropY);
+
+    final dragGesture = await tester.startGesture(
+      tester.getCenter(find.bySemanticsLabel('Quarter palette symbol')),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 120));
+    await dragGesture.moveTo(dropPoint);
+    await tester.pump();
+    await dragGesture.up();
+    await tester.pumpAndSettle();
+
+    final expectedScore = score.insertSymbolAt(
+      0,
+      0,
+      1,
+      const Note(step: 'E', octave: 4, duration: 1, type: 'quarter'),
+    );
+    await tester.tapAt(
+      origin + _symbolCenterOffset(expectedScore, measureIndex: 0, symbolIndex: 1),
+    );
+    await tester.pump();
+
+    expect(find.text('E4'), findsOneWidget);
+  });
+
+  testWidgets('palette drop inserts rest in empty measure and undo restores empty', (
+    tester,
+  ) async {
+    final score = buildScore(withSymbols: false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+
+    final origin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+    final target = _measureTargetOffset(score, measureIndex: 0);
+    final dropPoint = origin + Offset(target.measureCenterX, target.lineYs.first - 20);
+
+    final dragGesture = await tester.startGesture(
+      tester.getCenter(find.bySemanticsLabel('H Rest palette symbol')),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 120));
+    await dragGesture.moveTo(dropPoint);
+    await tester.pump();
+    await dragGesture.up();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Rest'), findsOneWidget);
+    expect(find.text('half'), findsOneWidget);
+
+    final undoButton = find.widgetWithText(OutlinedButton, 'Undo');
+    await tester.ensureVisible(undoButton);
+    await tester.tap(undoButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('None'), findsOneWidget);
+  });
+
   testWidgets('landscape keeps controls beside notation without overlap', (
     tester,
   ) async {
@@ -272,4 +376,45 @@ Offset _symbolCenterOffset(
   );
 
   return target.center;
+}
+
+_MeasureTargetOffset _measureTargetOffset(
+  Score score, {
+  required int measureIndex,
+}) {
+  const measuresPerRow = 4;
+  const minMeasureWidth = 140.0;
+  const rowHeight = 140.0;
+  const padding = EdgeInsets.all(16);
+
+  final measures = score.parts.first.measures;
+  final layout = const NotationLayoutCalculator().calculate(
+    measures: measures,
+    measuresPerRow: measuresPerRow,
+    minMeasureWidth: minMeasureWidth,
+    rowHeight: rowHeight,
+    padding: padding,
+  );
+  final target = ScoreNotationPainter.buildMeasureTargets(
+    measures: measures,
+    measuresPerRow: layout.measuresPerRow,
+    minMeasureWidth: minMeasureWidth,
+    rowHeight: rowHeight,
+    padding: padding,
+    rowPrefixWidth: layout.rowPrefixWidth,
+  ).firstWhere((entry) => entry.measureIndex == measureIndex);
+  return _MeasureTargetOffset(
+    measureCenterX: (target.measureStartX + target.measureEndX) / 2,
+    lineYs: target.lineYs,
+  );
+}
+
+class _MeasureTargetOffset {
+  const _MeasureTargetOffset({
+    required this.measureCenterX,
+    required this.lineYs,
+  });
+
+  final double measureCenterX;
+  final List<double> lineYs;
 }


### PR DESCRIPTION
### Motivation
- Enable inserting palette symbols into a score by dropping onto the notation with precise x-index placement and y-to-pitch mapping and to show a visual insertion indicator while hovering.
- Provide programmatic targets for measures to compute valid drop regions and index locations for insertion.

### Description
- Add `NotationInsertionFeedback` and `NotationMeasureTarget` types, expose `ScoreNotationPainter.buildMeasureTargets`, and wire an `insertionFeedback` property through `ScoreNotationViewer` and `ScoreNotationPainter` to render an insertion marker. 
- Implement insertion indicator drawing (`_drawInsertionIndicator`) and insertion X calculation (`_insertionXForIndex`) in `ScoreNotationPainter`, and update `shouldRepaint` to consider `insertionFeedback`.
- Add editor/API support for inserting symbols via `EditorActions.insertSymbolAt` and integrate drop handling in `EditorShellScreen` including hover feedback (`_handleDragHover`), resolving measure/insert index (`_resolveInsertionTarget` / `_insertionIndexForX`), mapping drop Y to pitch via `PitchCalculator`, and converting dropped `MusicalSymbol` to `Note`/`Rest` before inserting.
- Hook up `DragTarget` callbacks in the editor UI to update hover feedback, accept drops, and clear feedback on leave; add a `GlobalKey` to the notation viewer and build measure targets using `NotationLayoutCalculator`.
- Add utility test helpers (`_measureTargetOffset`, `_MeasureTargetOffset`) used by new widget tests.

### Testing
- Added widget tests in `test/features/editor/presentation/editor_shell_screen_test.dart` for dropping a quarter note (verifies x-index insertion and y->pitch mapping) and dropping a rest into an empty measure (verifies insertion and undo); these tests were executed and passed.
- Existing notation/drag-reorder widget test continued to run and passed locally after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce1fbe89a083209bdb06e189da245d)