### PR TITLE
Add draggable SymbolPalette to editor UI and update tests

### DIFF
--- a/lib/core/widgets/score_notation/score_notation_painter.dart
+++ b/lib/core/widgets/score_notation/score_notation_painter.dart
@@ -57,6 +57,13 @@ class ScoreNotationPainter extends CustomPainter {
     );
   }
 
+  static String _clefSignForRow(List<Measure> rowMeasures) {
+    for (final m in rowMeasures) {
+      if (m.clef != null) return m.clef!.sign;
+    }
+    return 'G';
+  }
+
   static List<_RowMetrics> _buildRowMetricsStatic({
     required List<Measure> measures,
     required int measuresPerRow,
@@ -89,6 +96,7 @@ class ScoreNotationPainter extends CustomPainter {
           rowStartX: rowStartX,
           contentStartX: contentStartX,
           rowEndX: rowEndX,
+          clefSign: _clefSignForRow(rowMeasures),
         ),
       );
     }
@@ -131,7 +139,7 @@ class ScoreNotationPainter extends CustomPainter {
           final symbol = measure.symbols[symbolIndex];
           final progress = (symbolIndex + 1) / (measure.symbols.length + 1);
           final x = measureStartX + innerPadding + (drawableWidth * progress);
-          final y = _symbolCenterY(symbol, row.staffTop, row.staffBottom);
+          final y = _symbolCenterY(symbol, row.staffTop, row.staffBottom, row.clefSign);
           targets.add(
             NotationSymbolTarget(
               measureIndex: row.globalStartMeasureIndex + measureInRow,
@@ -150,23 +158,26 @@ class ScoreNotationPainter extends CustomPainter {
     return targets;
   }
 
-  static double _symbolCenterY(ScoreSymbol symbol, double staffTop, double staffBottom) {
+  static double _symbolCenterY(
+    ScoreSymbol symbol,
+    double staffTop,
+    double staffBottom,
+    String clefSign,
+  ) {
     if (symbol is Note) {
       return StaffPitchMapper.yForPitch(
         step: symbol.step,
         octave: symbol.octave,
         bottomLineY: staffBottom,
         lineSpacing: staffLineSpacing,
+        clefSign: clefSign,
       );
     }
 
+    // Rests have fixed staff positions (clef-independent)
     final restType = symbol is Rest ? symbol.type.trim().toLowerCase() : '';
-    if (restType == 'whole') {
-      return staffTop + (staffLineSpacing * 3) + 4.3;
-    }
-    if (restType == 'half') {
-      return staffTop + (staffLineSpacing * 2) - 3.0;
-    }
+    if (restType == 'whole') return staffTop + (staffLineSpacing * 3) + 4.3;
+    if (restType == 'half') return staffTop + (staffLineSpacing * 2) - 3.0;
     return staffTop + (staffLineSpacing * 1.35) + 8.0;
   }
 
@@ -180,7 +191,12 @@ class ScoreNotationPainter extends CustomPainter {
       ..color = const Color(0xFF111827)
       ..strokeWidth = 1.2;
 
-    _drawTrebleClef(canvas, x: row.rowStartX + 10, y: row.staffTop - 14);
+    if (row.clefSign.toUpperCase() == 'F') {
+      _drawBassClef(canvas, x: row.rowStartX + 8, y: row.staffTop - 4);
+    } else {
+      _drawTrebleClef(canvas, x: row.rowStartX + 10, y: row.staffTop - 14);
+    }
+
     _drawRowSignatures(canvas, row);
 
     for (var i = 0; i < 5; i++) {
@@ -216,6 +232,7 @@ class ScoreNotationPainter extends CustomPainter {
         signatureX,
         keySig,
         staffBottom: row.staffBottom,
+        clefSign: row.clefSign,
       );
     }
 
@@ -265,6 +282,7 @@ class ScoreNotationPainter extends CustomPainter {
         measureEndX: nextMeasureX,
         staffTop: row.staffTop,
         staffBottom: row.staffBottom,
+        clefSign: row.clefSign,
       );
     }
   }
@@ -277,6 +295,7 @@ class ScoreNotationPainter extends CustomPainter {
     required double measureEndX,
     required double staffTop,
     required double staffBottom,
+    required String clefSign,
   }) {
     final insertTarget = insertionTarget;
     if (insertTarget != null && insertTarget.measureIndex == absoluteMeasureIndex) {
@@ -322,9 +341,7 @@ class ScoreNotationPainter extends CustomPainter {
         : 0.0;
 
     for (var i = 0; i < symbolCount; i++) {
-      if (activeDrag != null && i == activeDrag.draggedSymbolIndex) {
-        continue;
-      }
+      if (activeDrag != null && i == activeDrag.draggedSymbolIndex) continue;
       final symbol = measure.symbols[i];
       var visualIndex = i;
       if (activeDrag != null) {
@@ -341,38 +358,27 @@ class ScoreNotationPainter extends CustomPainter {
           octave: symbol.octave,
           bottomLineY: staffBottom,
           lineSpacing: staffLineSpacing,
+          clefSign: clefSign,
         );
         final isSelected =
-            selectedMeasureIndex == absoluteMeasureIndex &&
-            selectedSymbolIndex == i;
-        if (isSelected) {
-          _drawSelectionHighlight(canvas, Offset(x, y));
-        }
+            selectedMeasureIndex == absoluteMeasureIndex && selectedSymbolIndex == i;
+        if (isSelected) _drawSelectionHighlight(canvas, Offset(x, y));
         _drawNote(canvas, symbol, x: x, y: y, middleLineY: middleLineY);
       } else if (symbol is Rest) {
-        final y = _symbolCenterY(symbol, staffTop, staffBottom);
+        final y = _symbolCenterY(symbol, staffTop, staffBottom, clefSign);
         final isSelected =
-            selectedMeasureIndex == absoluteMeasureIndex &&
-            selectedSymbolIndex == i;
-        if (isSelected) {
-          _drawSelectionHighlight(canvas, Offset(x, y));
-        }
+            selectedMeasureIndex == absoluteMeasureIndex && selectedSymbolIndex == i;
+        if (isSelected) _drawSelectionHighlight(canvas, Offset(x, y));
         _drawRest(canvas, symbol, x: x, staffTop: staffTop);
       }
     }
 
     if (!hasDragInMeasure || draggedSymbol == null) return;
 
-    final dragY = _symbolCenterY(draggedSymbol, staffTop, staffBottom) - 8;
+    final dragY = _symbolCenterY(draggedSymbol, staffTop, staffBottom, clefSign) - 8;
     if (draggedSymbol is Note) {
       _drawSelectionHighlight(canvas, Offset(clampedDragX, dragY), radius: 16);
-      _drawNote(
-        canvas,
-        draggedSymbol,
-        x: clampedDragX,
-        y: dragY,
-        middleLineY: middleLineY,
-      );
+      _drawNote(canvas, draggedSymbol, x: clampedDragX, y: dragY, middleLineY: middleLineY);
     } else if (draggedSymbol is Rest) {
       _drawSelectionHighlight(canvas, Offset(clampedDragX, dragY), radius: 16);
       _drawRest(canvas, draggedSymbol, x: clampedDragX, staffTop: staffTop - 8);
@@ -415,11 +421,7 @@ class ScoreNotationPainter extends CustomPainter {
     canvas.save();
     canvas.translate(x, y);
     canvas.rotate(-0.35);
-    final noteRect = Rect.fromCenter(
-      center: Offset.zero,
-      width: headWidth,
-      height: headHeight,
-    );
+    final noteRect = Rect.fromCenter(center: Offset.zero, width: headWidth, height: headHeight);
     if (isWhole || isHalf) {
       canvas.drawOval(noteRect, strokePaint);
     } else {
@@ -430,13 +432,7 @@ class ScoreNotationPainter extends CustomPainter {
     if (isWhole) return;
 
     final stemUp = y > middleLineY;
-    _drawStemAndFlag(
-      canvas,
-      x: x,
-      y: y,
-      stemUp: stemUp,
-      drawFlag: isEighth,
-    );
+    _drawStemAndFlag(canvas, x: x, y: y, stemUp: stemUp, drawFlag: isEighth);
   }
 
   void _drawStemAndFlag(
@@ -476,12 +472,7 @@ class ScoreNotationPainter extends CustomPainter {
     canvas.drawPath(path, flagPaint);
   }
 
-  void _drawRest(
-    Canvas canvas,
-    Rest rest, {
-    required double x,
-    required double staffTop,
-  }) {
+  void _drawRest(Canvas canvas, Rest rest, {required double x, required double staffTop}) {
     final type = rest.type.trim().toLowerCase();
     final paint = Paint()
       ..color = const Color(0xFF111827)
@@ -489,22 +480,14 @@ class ScoreNotationPainter extends CustomPainter {
 
     if (type == 'whole') {
       final line4Y = staffTop + (staffLineSpacing * 3);
-      final rect = Rect.fromCenter(
-        center: Offset(x, line4Y + 4.3),
-        width: 16,
-        height: 4.8,
-      );
+      final rect = Rect.fromCenter(center: Offset(x, line4Y + 4.3), width: 16, height: 4.8);
       canvas.drawRect(rect, paint);
       return;
     }
 
     if (type == 'half') {
       final line3Y = staffTop + (staffLineSpacing * 2);
-      final rect = Rect.fromCenter(
-        center: Offset(x, line3Y - 3.0),
-        width: 16,
-        height: 4.8,
-      );
+      final rect = Rect.fromCenter(center: Offset(x, line3Y - 3.0), width: 16, height: 4.8);
       canvas.drawRect(rect, paint);
       return;
     }
@@ -536,28 +519,54 @@ class ScoreNotationPainter extends CustomPainter {
       text: TextSpan(text: text, style: style),
       textDirection: TextDirection.ltr,
     )..layout();
-
     textPainter.paint(canvas, Offset(x, y));
   }
 
-  void _drawTrebleClef(
-    Canvas canvas, {
-    required double x,
-    required double y,
-  }) {
+  void _drawTrebleClef(Canvas canvas, {required double x, required double y}) {
     final textPainter = TextPainter(
       text: const TextSpan(
         text: '𝄞',
-        style: TextStyle(
-          fontSize: 42,
-          color: Color(0xFF111827),
-          fontWeight: FontWeight.w500,
-        ),
+        style: TextStyle(fontSize: 42, color: Color(0xFF111827), fontWeight: FontWeight.w500),
       ),
       textDirection: TextDirection.ltr,
     )..layout();
-
     textPainter.paint(canvas, Offset(x, y));
+  }
+
+  void _drawBassClef(Canvas canvas, {required double x, required double y}) {
+    // Draw F-clef body using canvas primitives for reliability across platforms.
+    final inkPaint = Paint()
+      ..color = const Color(0xFF111827)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.6
+      ..strokeCap = StrokeCap.round;
+    final fillPaint = Paint()
+      ..color = const Color(0xFF111827)
+      ..style = PaintingStyle.fill;
+
+    // Curved body of the F clef
+    final bodyPath = Path();
+    final cx = x + 10.0;
+    final cy = y + staffLineSpacing * 1.5;
+    bodyPath.moveTo(cx, cy - staffLineSpacing * 1.5);
+    bodyPath.cubicTo(
+      cx + 14, cy - staffLineSpacing * 1.5,
+      cx + 18, cy - staffLineSpacing * 0.5,
+      cx + 12, cy,
+    );
+    bodyPath.cubicTo(
+      cx + 6, cy + staffLineSpacing * 0.5,
+      cx - 2, cy + staffLineSpacing * 0.8,
+      cx - 6, cy + staffLineSpacing * 2.0,
+    );
+    canvas.drawPath(bodyPath, inkPaint);
+
+    // Two dots to the right of the curve
+    final dotX = cx + 20.0;
+    final dot1Y = cy - staffLineSpacing * 0.6;
+    final dot2Y = cy + staffLineSpacing * 0.4;
+    canvas.drawCircle(Offset(dotX, dot1Y), 2.5, fillPaint);
+    canvas.drawCircle(Offset(dotX, dot2Y), 2.5, fillPaint);
   }
 
   double _drawKeySignature(
@@ -565,6 +574,7 @@ class ScoreNotationPainter extends CustomPainter {
     double x,
     KeySignature keySignature, {
     required double staffBottom,
+    required String clefSign,
   }) {
     final fifths = keySignature.fifths;
     if (fifths == 0) return x;
@@ -573,27 +583,24 @@ class ScoreNotationPainter extends CustomPainter {
     final count = fifths.abs().clamp(0, 7);
     final accidental = isSharp ? '#' : 'b';
 
-    const sharpOrder = [
-      ('F', 5),
-      ('C', 5),
-      ('G', 5),
-      ('D', 5),
-      ('A', 4),
-      ('E', 5),
-      ('B', 4),
+    const sharpOrderTreble = [
+      ('F', 5), ('C', 5), ('G', 5), ('D', 5), ('A', 4), ('E', 5), ('B', 4),
+    ];
+    const flatOrderTreble = [
+      ('B', 4), ('E', 5), ('A', 4), ('D', 5), ('G', 4), ('C', 5), ('F', 4),
+    ];
+    // Bass clef accidental positions
+    const sharpOrderBass = [
+      ('F', 3), ('C', 3), ('G', 3), ('D', 3), ('A', 2), ('E', 3), ('B', 2),
+    ];
+    const flatOrderBass = [
+      ('B', 2), ('E', 3), ('A', 2), ('D', 3), ('G', 2), ('C', 3), ('F', 2),
     ];
 
-    const flatOrder = [
-      ('B', 4),
-      ('E', 5),
-      ('A', 4),
-      ('D', 5),
-      ('G', 4),
-      ('C', 5),
-      ('F', 4),
-    ];
-
-    final order = isSharp ? sharpOrder : flatOrder;
+    final isBass = clefSign.toUpperCase() == 'F';
+    final order = isSharp
+        ? (isBass ? sharpOrderBass : sharpOrderTreble)
+        : (isBass ? flatOrderBass : flatOrderTreble);
 
     for (var i = 0; i < count; i++) {
       final pitch = order[i];
@@ -602,6 +609,7 @@ class ScoreNotationPainter extends CustomPainter {
         octave: pitch.$2,
         bottomLineY: staffBottom,
         lineSpacing: staffLineSpacing,
+        clefSign: clefSign,
       );
 
       final textPainter = TextPainter(
@@ -764,6 +772,7 @@ class _RowMetrics {
     required this.rowStartX,
     required this.contentStartX,
     required this.rowEndX,
+    required this.clefSign,
   });
 
   final int rowIndex;
@@ -774,4 +783,5 @@ class _RowMetrics {
   final double rowStartX;
   final double contentStartX;
   final double rowEndX;
+  final String clefSign;
 }

--- a/lib/core/widgets/score_notation/score_notation_painter.dart
+++ b/lib/core/widgets/score_notation/score_notation_painter.dart
@@ -21,6 +21,7 @@ class ScoreNotationPainter extends CustomPainter {
     this.selectedMeasureIndex,
     this.selectedSymbolIndex,
     this.dragFeedback,
+    this.insertionTarget,
   });
 
   final List<Measure> measures;
@@ -32,6 +33,7 @@ class ScoreNotationPainter extends CustomPainter {
   final int? selectedMeasureIndex;
   final int? selectedSymbolIndex;
   final NotationDragFeedback? dragFeedback;
+  final NotationInsertTarget? insertionTarget;
 
   static const double staffLineSpacing = 12;
   static const double tapTargetSize = 24;
@@ -276,6 +278,21 @@ class ScoreNotationPainter extends CustomPainter {
     required double staffTop,
     required double staffBottom,
   }) {
+    final insertTarget = insertionTarget;
+    if (insertTarget != null && insertTarget.measureIndex == absoluteMeasureIndex) {
+      final linePaint = Paint()
+        ..color = const Color(0xFF60A5FA)
+        ..strokeWidth = 2.0;
+      final x = insertTarget.indicatorX
+          .clamp(measureStartX + 2, measureEndX - 2)
+          .toDouble();
+      canvas.drawLine(
+        Offset(x, staffTop - 8),
+        Offset(x, staffBottom + 8),
+        linePaint,
+      );
+    }
+
     if (measure.symbols.isEmpty) return;
 
     final symbolCount = measure.symbols.length;
@@ -652,7 +669,8 @@ class ScoreNotationPainter extends CustomPainter {
         oldDelegate.rowPrefixWidth != rowPrefixWidth ||
         oldDelegate.selectedMeasureIndex != selectedMeasureIndex ||
         oldDelegate.selectedSymbolIndex != selectedSymbolIndex ||
-        oldDelegate.dragFeedback != dragFeedback;
+        oldDelegate.dragFeedback != dragFeedback ||
+        oldDelegate.insertionTarget != insertionTarget;
   }
 }
 
@@ -699,6 +717,41 @@ class NotationDragFeedback {
       draggedSymbolIndex.hashCode ^
       targetSymbolIndex.hashCode ^
       dragX.hashCode;
+}
+
+class NotationInsertTarget {
+  const NotationInsertTarget({
+    required this.measureIndex,
+    required this.insertIndex,
+    required this.indicatorX,
+    required this.step,
+    required this.octave,
+  });
+
+  final int measureIndex;
+  final int insertIndex;
+  final double indicatorX;
+  final String step;
+  final int octave;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NotationInsertTarget &&
+        other.measureIndex == measureIndex &&
+        other.insertIndex == insertIndex &&
+        other.indicatorX == indicatorX &&
+        other.step == step &&
+        other.octave == octave;
+  }
+
+  @override
+  int get hashCode =>
+      measureIndex.hashCode ^
+      insertIndex.hashCode ^
+      indicatorX.hashCode ^
+      step.hashCode ^
+      octave.hashCode;
 }
 
 class _RowMetrics {

--- a/lib/core/widgets/score_notation/staff_pitch_mapper.dart
+++ b/lib/core/widgets/score_notation/staff_pitch_mapper.dart
@@ -31,4 +31,26 @@ class StaffPitchMapper {
     final offset = offsetFromTrebleBottomLine(step: step, octave: octave);
     return bottomLineY - (offset * (lineSpacing / 2));
   }
+
+  static StaffPitch pitchForY({
+    required double y,
+    required double bottomLineY,
+    required double lineSpacing,
+  }) {
+    const e4Index = 2;
+    const e4Absolute = 4 * 7 + e4Index;
+
+    final offset = ((bottomLineY - y) / (lineSpacing / 2)).round();
+    final absolute = e4Absolute + offset;
+    final stepIndex = ((absolute % _steps.length) + _steps.length) % _steps.length;
+    final octave = (absolute - stepIndex) ~/ _steps.length;
+    return StaffPitch(step: _steps[stepIndex], octave: octave);
+  }
+}
+
+class StaffPitch {
+  const StaffPitch({required this.step, required this.octave});
+
+  final String step;
+  final int octave;
 }

--- a/lib/core/widgets/score_notation/staff_pitch_mapper.dart
+++ b/lib/core/widgets/score_notation/staff_pitch_mapper.dart
@@ -1,34 +1,45 @@
 class StaffPitchMapper {
   static const List<String> _steps = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
 
-  /// Returns the diatonic step offset from E4 (treble bottom line).
-  ///
-  /// Every +1 offset means one staff step upward (line->space or space->line).
-  ///
-  /// Formula:
-  /// absoluteDiatonic = octave * 7 + stepIndex(C=0..B=6)
-  /// offsetFromE4 = absoluteDiatonic - absoluteDiatonic(E4)
-  static int offsetFromTrebleBottomLine({
+  /// Returns the bottom staff line reference note for a given clef sign.
+  /// - G (treble) clef: bottom line = E4
+  /// - F (bass) clef:   bottom line = G2
+  static ({String step, int octave}) bottomLineRef(String clefSign) {
+    if (clefSign.toUpperCase() == 'F') return (step: 'G', octave: 2);
+    return (step: 'E', octave: 4);
+  }
+
+  /// Returns the diatonic step offset from the bottom line of the given clef.
+  static int offsetFromBottomLine({
     required String step,
     required int octave,
+    String clefSign = 'G',
   }) {
+    final ref = bottomLineRef(clefSign);
     final normalized = step.trim().toUpperCase();
     final stepIndex = _steps.indexOf(normalized);
     if (stepIndex < 0) return 0;
-
-    const e4Index = 2; // E in C D E F G A B.
-    const e4Absolute = 4 * 7 + e4Index;
+    final refIndex = _steps.indexOf(ref.step);
     final absolute = octave * 7 + stepIndex;
-    return absolute - e4Absolute;
+    final refAbsolute = ref.octave * 7 + refIndex;
+    return absolute - refAbsolute;
   }
+
+  /// Legacy name — kept for backward compatibility. Assumes treble clef.
+  static int offsetFromTrebleBottomLine({
+    required String step,
+    required int octave,
+  }) =>
+      offsetFromBottomLine(step: step, octave: octave, clefSign: 'G');
 
   static double yForPitch({
     required String step,
     required int octave,
     required double bottomLineY,
     required double lineSpacing,
+    String clefSign = 'G',
   }) {
-    final offset = offsetFromTrebleBottomLine(step: step, octave: octave);
+    final offset = offsetFromBottomLine(step: step, octave: octave, clefSign: clefSign);
     return bottomLineY - (offset * (lineSpacing / 2));
   }
 
@@ -36,12 +47,14 @@ class StaffPitchMapper {
     required double y,
     required double bottomLineY,
     required double lineSpacing,
+    String clefSign = 'G',
   }) {
-    const e4Index = 2;
-    const e4Absolute = 4 * 7 + e4Index;
+    final ref = bottomLineRef(clefSign);
+    final refIndex = _steps.indexOf(ref.step);
+    final refAbsolute = ref.octave * 7 + refIndex;
 
     final offset = ((bottomLineY - y) / (lineSpacing / 2)).round();
-    final absolute = e4Absolute + offset;
+    final absolute = refAbsolute + offset;
     final stepIndex = ((absolute % _steps.length) + _steps.length) % _steps.length;
     final octave = (absolute - stepIndex) ~/ _steps.length;
     return StaffPitch(step: _steps[stepIndex], octave: octave);

--- a/lib/core/widgets/score_notation_viewer.dart
+++ b/lib/core/widgets/score_notation_viewer.dart
@@ -4,6 +4,7 @@ import '../models/measure.dart';
 import '../models/score.dart';
 import 'score_notation/notation_layout.dart';
 import 'score_notation/score_notation_painter.dart';
+import 'score_notation/staff_pitch_mapper.dart';
 
 export 'score_notation/staff_pitch_mapper.dart';
 
@@ -428,7 +429,7 @@ class _NotationCanvasFrame extends StatelessWidget {
         if (box == null) return;
         onExternalAccept!(box.globalToLocal(details.offset), details.data);
       },
-      builder: (context, _, __) => Container(
+      builder: (context, _, _) => Container(
         decoration: BoxDecoration(
           color: backgroundColor,
           borderRadius: BorderRadius.circular(10),

--- a/lib/core/widgets/score_notation_viewer.dart
+++ b/lib/core/widgets/score_notation_viewer.dart
@@ -22,7 +22,9 @@ class ScoreNotationViewer extends StatefulWidget {
     this.backgroundColor = const Color(0xFFF9FAFB),
     this.selectedMeasureIndex,
     this.selectedSymbolIndex,
+    this.insertMode = false,
     this.onSymbolTap,
+    this.onInsertTap,
     this.onSymbolReorder,
     this.canAcceptExternalDrop,
     this.onExternalDrop,
@@ -36,7 +38,11 @@ class ScoreNotationViewer extends StatefulWidget {
   final Color backgroundColor;
   final int? selectedMeasureIndex;
   final int? selectedSymbolIndex;
+  /// When true, taps resolve to [NotationInsertTarget] via [onInsertTap]
+  /// instead of the normal symbol-selection [onSymbolTap].
+  final bool insertMode;
   final ValueChanged<NotationSymbolTarget?>? onSymbolTap;
+  final ValueChanged<NotationInsertTarget?>? onInsertTap;
   final ValueChanged<NotationSymbolReorder>? onSymbolReorder;
   final bool Function(Object data)? canAcceptExternalDrop;
   final void Function(NotationInsertTarget target, Object data)? onExternalDrop;
@@ -115,23 +121,32 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
           });
         }
       },
-      onTapUp: widget.onSymbolTap == null
+      onTapUp: (widget.onSymbolTap == null && widget.onInsertTap == null)
           ? null
           : (position) {
               final adjusted = position.translate(
                 _horizontalController.hasClients ? _horizontalController.offset : 0,
                 0,
               );
-              final targets = ScoreNotationPainter.buildSymbolTargets(
-                measures: measures,
-                measuresPerRow: layout.measuresPerRow,
-                minMeasureWidth: widget.minMeasureWidth,
-                rowHeight: widget.rowHeight,
-                padding: widget.padding,
-                rowPrefixWidth: layout.rowPrefixWidth,
-              );
-              final tapped = _nearestTarget(adjusted, targets);
-              widget.onSymbolTap?.call(tapped);
+              if (widget.insertMode) {
+                final target = _resolveInsertTarget(
+                  measures: measures,
+                  layout: layout,
+                  position: adjusted,
+                );
+                widget.onInsertTap?.call(target);
+              } else {
+                final targets = ScoreNotationPainter.buildSymbolTargets(
+                  measures: measures,
+                  measuresPerRow: layout.measuresPerRow,
+                  minMeasureWidth: widget.minMeasureWidth,
+                  rowHeight: widget.rowHeight,
+                  padding: widget.padding,
+                  rowPrefixWidth: layout.rowPrefixWidth,
+                );
+                final tapped = _nearestTarget(adjusted, targets);
+                widget.onSymbolTap?.call(tapped);
+              }
             },
       onLongPressStart: widget.onSymbolReorder == null
           ? null

--- a/lib/core/widgets/score_notation_viewer.dart
+++ b/lib/core/widgets/score_notation_viewer.dart
@@ -23,6 +23,8 @@ class ScoreNotationViewer extends StatefulWidget {
     this.selectedSymbolIndex,
     this.onSymbolTap,
     this.onSymbolReorder,
+    this.canAcceptExternalDrop,
+    this.onExternalDrop,
   });
 
   final Score? score;
@@ -35,6 +37,8 @@ class ScoreNotationViewer extends StatefulWidget {
   final int? selectedSymbolIndex;
   final ValueChanged<NotationSymbolTarget?>? onSymbolTap;
   final ValueChanged<NotationSymbolReorder>? onSymbolReorder;
+  final bool Function(Object data)? canAcceptExternalDrop;
+  final void Function(NotationInsertTarget target, Object data)? onExternalDrop;
 
   @override
   State<ScoreNotationViewer> createState() => _ScoreNotationViewerState();
@@ -45,6 +49,7 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
   final NotationLayoutCalculator _layoutCalculator =
       const NotationLayoutCalculator();
   _NotationDragSession? _dragSession;
+  NotationInsertTarget? _externalInsertTarget;
 
   @override
   void dispose() {
@@ -72,6 +77,43 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
       backgroundColor: widget.backgroundColor,
       horizontalController: _horizontalController,
       size: layout.size,
+      canAcceptExternalData: widget.canAcceptExternalDrop,
+      onExternalDragMove: (position, data) {
+        if (widget.canAcceptExternalDrop?.call(data) == false) return;
+        final adjusted = _adjustForHorizontalScroll(position);
+        final target = _resolveInsertTarget(
+          measures: measures,
+          layout: layout,
+          position: adjusted,
+        );
+        if (target == _externalInsertTarget) return;
+        setState(() {
+          _externalInsertTarget = target;
+        });
+      },
+      onExternalDragLeave: () {
+        if (_externalInsertTarget == null) return;
+        setState(() {
+          _externalInsertTarget = null;
+        });
+      },
+      onExternalAccept: (position, data) {
+        if (widget.canAcceptExternalDrop?.call(data) == false) return;
+        final adjusted = _adjustForHorizontalScroll(position);
+        final target = _resolveInsertTarget(
+          measures: measures,
+          layout: layout,
+          position: adjusted,
+        );
+        if (target != null) {
+          widget.onExternalDrop?.call(target, data);
+        }
+        if (_externalInsertTarget != null) {
+          setState(() {
+            _externalInsertTarget = null;
+          });
+        }
+      },
       onTapUp: widget.onSymbolTap == null
           ? null
           : (position) {
@@ -117,6 +159,7 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
                 targetSymbolIndex: _dragSession!.toSymbolIndex,
                 dragX: _dragSession!.dragPosition.dx,
               ),
+        insertionTarget: _externalInsertTarget,
       ),
     );
   }
@@ -240,6 +283,70 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
     return insertIndex.clamp(0, symbolCount - 1);
   }
 
+  NotationInsertTarget? _resolveInsertTarget({
+    required List<Measure> measures,
+    required NotationLayout layout,
+    required Offset position,
+  }) {
+    final rowCount = (measures.length / layout.measuresPerRow).ceil();
+    final contentStartX = widget.padding.left + layout.rowPrefixWidth;
+    const innerPadding = 16.0;
+
+    for (var rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      final rowStartMeasure = rowIndex * layout.measuresPerRow;
+      final rowEndExclusive =
+          (rowStartMeasure + layout.measuresPerRow).clamp(0, measures.length).toInt();
+      if (rowStartMeasure >= rowEndExclusive) continue;
+
+      final staffTop = widget.padding.top + rowIndex * widget.rowHeight + 28;
+      final staffBottom = staffTop + ScoreNotationPainter.staffLineSpacing * 4;
+      final isWithinRowBand = position.dy >= (staffTop - 28) && position.dy <= (staffBottom + 28);
+      if (!isWithinRowBand) continue;
+
+      for (var measureInRow = 0; measureInRow < rowEndExclusive - rowStartMeasure; measureInRow++) {
+        final absoluteMeasureIndex = rowStartMeasure + measureInRow;
+        final measureStartX = contentStartX + (measureInRow * widget.minMeasureWidth);
+        final measureEndX = measureStartX + widget.minMeasureWidth;
+        if (position.dx < measureStartX || position.dx > measureEndX) continue;
+
+        final measure = measures[absoluteMeasureIndex];
+        final drawableWidth = ((measureEndX - measureStartX) - (innerPadding * 2))
+            .clamp(12.0, double.infinity)
+            .toDouble();
+        final clampedX = position.dx
+            .clamp(measureStartX + innerPadding, measureEndX - innerPadding)
+            .toDouble();
+        final symbolCount = measure.symbols.length;
+        var insertIndex = 0;
+
+        for (var i = 0; i < symbolCount; i++) {
+          final progress = (i + 1) / (symbolCount + 1);
+          final symbolX = measureStartX + innerPadding + (drawableWidth * progress);
+          if (clampedX > symbolX) {
+            insertIndex++;
+          }
+        }
+
+        final indicatorProgress = (insertIndex + 1) / (symbolCount + 2);
+        final indicatorX = measureStartX + innerPadding + (drawableWidth * indicatorProgress);
+        final pitch = StaffPitchMapper.pitchForY(
+          y: position.dy,
+          bottomLineY: staffBottom,
+          lineSpacing: ScoreNotationPainter.staffLineSpacing,
+        );
+
+        return NotationInsertTarget(
+          measureIndex: absoluteMeasureIndex,
+          insertIndex: insertIndex,
+          indicatorX: indicatorX,
+          step: pitch.step,
+          octave: pitch.octave,
+        );
+      }
+    }
+    return null;
+  }
+
   Offset _adjustForHorizontalScroll(Offset position) {
     return position.translate(
       _horizontalController.hasClients ? _horizontalController.offset : 0,
@@ -281,6 +388,10 @@ class _NotationCanvasFrame extends StatelessWidget {
     this.onLongPressMoveUpdate,
     this.onLongPressEnd,
     this.onLongPressCancel,
+    this.canAcceptExternalData,
+    this.onExternalDragMove,
+    this.onExternalDragLeave,
+    this.onExternalAccept,
   });
 
   final Color backgroundColor;
@@ -292,31 +403,54 @@ class _NotationCanvasFrame extends StatelessWidget {
   final ValueChanged<Offset>? onLongPressMoveUpdate;
   final ValueChanged<Offset>? onLongPressEnd;
   final VoidCallback? onLongPressCancel;
+  final bool Function(Object data)? canAcceptExternalData;
+  final void Function(Offset position, Object data)? onExternalDragMove;
+  final VoidCallback? onExternalDragLeave;
+  final void Function(Offset position, Object data)? onExternalAccept;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: backgroundColor,
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: const Color(0xFFE5E7EB)),
-      ),
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTapUp: onTapUp == null ? null : (details) => onTapUp!(details.localPosition),
-        onLongPressStart: onLongPressStart == null
-            ? null
-            : (details) => onLongPressStart!(details.localPosition),
-        onLongPressMoveUpdate: onLongPressMoveUpdate == null
-            ? null
-            : (details) => onLongPressMoveUpdate!(details.localPosition),
-        onLongPressEnd:
-            onLongPressEnd == null ? null : (details) => onLongPressEnd!(details.localPosition),
-        onLongPressCancel: onLongPressCancel,
-        child: SingleChildScrollView(
-          controller: horizontalController,
-          scrollDirection: Axis.horizontal,
-          child: CustomPaint(size: size, painter: painter),
+    return DragTarget<Object>(
+      onWillAcceptWithDetails: (details) {
+        if (canAcceptExternalData == null) return false;
+        return canAcceptExternalData!(details.data);
+      },
+      onMove: (details) {
+        if (onExternalDragMove == null) return;
+        final box = context.findRenderObject() as RenderBox?;
+        if (box == null) return;
+        onExternalDragMove!(box.globalToLocal(details.offset), details.data);
+      },
+      onLeave: (_) => onExternalDragLeave?.call(),
+      onAcceptWithDetails: (details) {
+        if (onExternalAccept == null) return;
+        final box = context.findRenderObject() as RenderBox?;
+        if (box == null) return;
+        onExternalAccept!(box.globalToLocal(details.offset), details.data);
+      },
+      builder: (context, _, __) => Container(
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: const Color(0xFFE5E7EB)),
+        ),
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTapUp: onTapUp == null ? null : (details) => onTapUp!(details.localPosition),
+          onLongPressStart: onLongPressStart == null
+              ? null
+              : (details) => onLongPressStart!(details.localPosition),
+          onLongPressMoveUpdate: onLongPressMoveUpdate == null
+              ? null
+              : (details) => onLongPressMoveUpdate!(details.localPosition),
+          onLongPressEnd:
+              onLongPressEnd == null ? null : (details) => onLongPressEnd!(details.localPosition),
+          onLongPressCancel: onLongPressCancel,
+          child: SingleChildScrollView(
+            controller: horizontalController,
+            scrollDirection: Axis.horizontal,
+            child: CustomPaint(size: size, painter: painter),
+          ),
         ),
       ),
     );

--- a/lib/features/editor/domain/editor_actions.dart
+++ b/lib/features/editor/domain/editor_actions.dart
@@ -12,9 +12,9 @@ class DurationSpec {
   final int divisions;
 }
 
-const DurationSpec wholeDuration = DurationSpec('whole', 4);
-const DurationSpec halfDuration = DurationSpec('half', 2);
-const DurationSpec quarterDuration = DurationSpec('quarter', 1);
+const DurationSpec wholeDuration = DurationSpec('whole', 8);
+const DurationSpec halfDuration = DurationSpec('half', 4);
+const DurationSpec quarterDuration = DurationSpec('quarter', 2);
 const DurationSpec eighthDuration = DurationSpec('eighth', 1);
 
 extension EditorActions on EditorState {
@@ -86,7 +86,7 @@ extension EditorActions on EditorState {
     if (selectedPartIndex == null || selectedMeasureIndex == null) return this;
 
     return _appendToSelectedMeasure(
-      const Note(step: 'C', octave: 4, duration: 1, type: 'quarter'),
+      const Note(step: 'C', octave: 4, duration: 2, type: 'quarter'),
     );
   }
 
@@ -94,7 +94,7 @@ extension EditorActions on EditorState {
     if (selectedPartIndex == null || selectedMeasureIndex == null) return this;
 
     return _appendToSelectedMeasure(
-      const Rest(duration: 1, type: 'quarter'),
+      const Rest(duration: 2, type: 'quarter'),
     );
   }
 

--- a/lib/features/editor/domain/editor_actions.dart
+++ b/lib/features/editor/domain/editor_actions.dart
@@ -231,6 +231,33 @@ extension EditorActions on EditorState {
     );
   }
 
+  EditorState insertSymbolAtMeasureIndex({
+    required int measureIndex,
+    required int insertIndex,
+    required ScoreSymbol symbol,
+  }) {
+    if (score.parts.isEmpty) return this;
+    const partIndex = 0;
+    final measures = score.parts[partIndex].measures;
+    if (measureIndex < 0 || measureIndex >= measures.length) return this;
+    if (insertIndex < 0 || insertIndex > measures[measureIndex].symbols.length) return this;
+
+    final nextScore = score.insertSymbolAt(
+      partIndex,
+      measureIndex,
+      insertIndex,
+      symbol,
+    );
+
+    return applyEdit(
+      score: nextScore,
+      selectedPartIndex: partIndex,
+      selectedMeasureIndex: measureIndex,
+      selectedSymbolIndex: insertIndex,
+      selectedSymbol: symbol,
+    );
+  }
+
   EditorState _replaceSelectedSymbol(ScoreSymbol symbol) {
     final partIndex = selectedPartIndex!;
     final measureIndex = selectedMeasureIndex!;

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -5,7 +5,6 @@ import 'package:note_vision/core/models/score.dart';
 import 'package:note_vision/core/models/score_symbol.dart';
 import 'package:note_vision/core/widgets/score_notation/score_notation_painter.dart';
 import 'package:note_vision/core/theme/app_theme.dart';
-import 'package:note_vision/core/theme/responsive_layout.dart';
 import 'package:note_vision/core/widgets/score_notation_viewer.dart';
 import 'package:note_vision/features/editor/domain/editor_actions.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
@@ -32,6 +31,8 @@ class EditorShellScreen extends StatefulWidget {
 class _EditorShellScreenState extends State<EditorShellScreen> {
   late EditorState _editorState;
   double _canvasZoom = 1.0;
+  bool _insertMode = false;
+  PaletteSymbolType? _insertSymbolType;
 
   @override
   void initState() {
@@ -49,22 +50,20 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
 
   void _onNotationSymbolTap(int measureIndex, int symbolIndex) {
     _updateState((state) {
-      final isSameSelection =
+      final isSame =
           state.selectedPartIndex == 0 &&
           state.selectedMeasureIndex == measureIndex &&
           state.selectedSymbolIndex == symbolIndex;
-
-      if (isSameSelection) return _clearSymbolSelection(state);
+      if (isSame) return _clearSymbolSelection(state);
 
       final parts = state.score.parts;
-      if (parts.isEmpty || measureIndex < 0 || measureIndex >= parts.first.measures.length) {
+      if (parts.isEmpty || measureIndex >= parts.first.measures.length) {
         return state.copyWith(clearSelection: true);
       }
       final symbols = parts.first.measures[measureIndex].symbols;
       if (symbolIndex < 0 || symbolIndex >= symbols.length) {
         return _clearSymbolSelection(state);
       }
-
       return state.copyWith(
         selectedPartIndex: 0,
         selectedMeasureIndex: measureIndex,
@@ -74,9 +73,10 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
     });
   }
 
-  void _onPaletteDrop(NotationInsertTarget target, Object data) {
-    if (data is! PaletteDragData) return;
-    final symbol = _buildDroppedSymbol(data.type, target);
+  void _onInsertTap(NotationInsertTarget? target) {
+    if (target == null) return;
+    final type = _insertSymbolType ?? PaletteSymbolType.quarterNote;
+    final symbol = _buildSymbol(type, target);
     _updateState(
       (state) => state.insertSymbolAtMeasureIndex(
         measureIndex: target.measureIndex,
@@ -86,52 +86,40 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
     );
   }
 
-  ScoreSymbol _buildDroppedSymbol(PaletteSymbolType type, NotationInsertTarget target) {
+  void _onPaletteDrop(NotationInsertTarget target, Object data) {
+    if (data is! PaletteDragData) return;
+    final symbol = _buildSymbol(data.type, target);
+    _updateState(
+      (state) => state.insertSymbolAtMeasureIndex(
+        measureIndex: target.measureIndex,
+        insertIndex: target.insertIndex,
+        symbol: symbol,
+      ),
+    );
+  }
+
+  ScoreSymbol _buildSymbol(PaletteSymbolType type, NotationInsertTarget target) {
     switch (type) {
       case PaletteSymbolType.wholeNote:
-        return Note(
-          step: target.step,
-          octave: target.octave.clamp(1, 7).toInt(),
-          duration: 4,
-          type: 'whole',
-        );
+        return Note(step: target.step, octave: target.octave.clamp(1, 7).toInt(), duration: 8, type: 'whole');
       case PaletteSymbolType.halfNote:
-        return Note(
-          step: target.step,
-          octave: target.octave.clamp(1, 7).toInt(),
-          duration: 2,
-          type: 'half',
-        );
+        return Note(step: target.step, octave: target.octave.clamp(1, 7).toInt(), duration: 4, type: 'half');
       case PaletteSymbolType.quarterNote:
-        return Note(
-          step: target.step,
-          octave: target.octave.clamp(1, 7).toInt(),
-          duration: 1,
-          type: 'quarter',
-        );
+        return Note(step: target.step, octave: target.octave.clamp(1, 7).toInt(), duration: 2, type: 'quarter');
       case PaletteSymbolType.eighthNote:
-        return Note(
-          step: target.step,
-          octave: target.octave.clamp(1, 7).toInt(),
-          duration: 1,
-          type: 'eighth',
-        );
+        return Note(step: target.step, octave: target.octave.clamp(1, 7).toInt(), duration: 1, type: 'eighth');
       case PaletteSymbolType.wholeRest:
-        return const Rest(duration: 4, type: 'whole');
+        return const Rest(duration: 8, type: 'whole');
       case PaletteSymbolType.halfRest:
-        return const Rest(duration: 2, type: 'half');
+        return const Rest(duration: 4, type: 'half');
       case PaletteSymbolType.quarterRest:
-        return const Rest(duration: 1, type: 'quarter');
+        return const Rest(duration: 2, type: 'quarter');
     }
   }
 
   EditorState _withDefaultMeasureContext(EditorState state) {
-    if (state.selectedPartIndex != null && state.selectedMeasureIndex != null) {
-      return state;
-    }
-    if (state.score.parts.isEmpty || state.score.parts.first.measures.isEmpty) {
-      return state;
-    }
+    if (state.selectedPartIndex != null && state.selectedMeasureIndex != null) return state;
+    if (state.score.parts.isEmpty || state.score.parts.first.measures.isEmpty) return state;
     return state.copyWith(selectedPartIndex: 0, selectedMeasureIndex: 0);
   }
 
@@ -146,9 +134,24 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
     );
   }
 
-  void _changeZoom(double delta) {
+  void _toggleInsertMode() {
     setState(() {
-      _canvasZoom = (_canvasZoom + delta).clamp(0.75, 2.0).toDouble();
+      _insertMode = !_insertMode;
+      if (!_insertMode) _insertSymbolType = null;
+    });
+  }
+
+  void _onPaletteTypeTap(PaletteSymbolType type) {
+    setState(() {
+      if (!_insertMode) {
+        _insertMode = true;
+        _insertSymbolType = type;
+      } else if (_insertSymbolType == type) {
+        _insertMode = false;
+        _insertSymbolType = null;
+      } else {
+        _insertSymbolType = type;
+      }
     });
   }
 
@@ -168,105 +171,62 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final horizontalPadding = ResponsiveLayout.horizontalPadding(constraints.maxWidth);
             final isLandscape = constraints.maxWidth > constraints.maxHeight;
-            final controlPanelWidth = (constraints.maxWidth * 0.32).clamp(280.0, 360.0);
-            final notationPanel = Container(
-              decoration: BoxDecoration(
-                color: AppColors.surface,
-                borderRadius: BorderRadius.circular(14),
-                border: Border.all(color: AppColors.border),
-              ),
-              child: SingleChildScrollView(
-                child: Padding(
-                  padding: const EdgeInsets.all(8),
-                  child: ScoreNotationViewer(
-                    score: _editorState.score,
-                    minMeasureWidth: 220 * _canvasZoom,
-                    selectedMeasureIndex: _editorState.selectedMeasureIndex,
-                    selectedSymbolIndex: _editorState.selectedSymbolIndex,
-                    canAcceptExternalDrop: (data) => data is PaletteDragData,
-                    onExternalDrop: _onPaletteDrop,
-                    onSymbolTap: (target) {
-                      if (target == null) {
-                        _updateState((state) => _clearSymbolSelection(state));
-                        return;
-                      }
-                      _onNotationSymbolTap(target.measureIndex, target.symbolIndex);
-                    },
-                    onSymbolReorder: (event) {
-                      _updateState(
-                        (state) => state.reorderSymbolWithinMeasure(
-                          measureIndex: event.measureIndex,
-                          fromSymbolIndex: event.fromSymbolIndex,
-                          toSymbolIndex: event.toSymbolIndex,
-                        ),
-                      );
-                    },
+
+            final notationArea = _NotationArea(
+              editorState: _editorState,
+              canvasZoom: _canvasZoom,
+              insertMode: _insertMode,
+              insertSymbolType: _insertSymbolType,
+              onZoomIn: _canvasZoom < 2.0 ? () => setState(() => _canvasZoom = (_canvasZoom + 0.1).clamp(0.75, 2.0)) : null,
+              onZoomOut: _canvasZoom > 0.75 ? () => setState(() => _canvasZoom = (_canvasZoom - 0.1).clamp(0.75, 2.0)) : null,
+              onToggleInsertMode: _toggleInsertMode,
+              onPaletteTypeTap: _onPaletteTypeTap,
+              onSymbolTap: (target) {
+                if (target == null) {
+                  _updateState((s) => _clearSymbolSelection(s));
+                } else {
+                  _onNotationSymbolTap(target.measureIndex, target.symbolIndex);
+                }
+              },
+              onInsertTap: _onInsertTap,
+              onSymbolReorder: (event) {
+                _updateState(
+                  (s) => s.reorderSymbolWithinMeasure(
+                    measureIndex: event.measureIndex,
+                    fromSymbolIndex: event.fromSymbolIndex,
+                    toSymbolIndex: event.toSymbolIndex,
                   ),
-                ),
-              ),
+                );
+              },
+              onExternalDrop: _onPaletteDrop,
             );
 
-
-            final notationWithPalette = Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(8, 8, 8, 6),
-                  child: Align(
-                    alignment: Alignment.centerRight,
-                    child: _ZoomControls(
-                      zoomPercent: (_canvasZoom * 100).round(),
-                      onZoomOut: _canvasZoom > 0.75 ? () => _changeZoom(-0.1) : null,
-                      onZoomIn: _canvasZoom < 2.0 ? () => _changeZoom(0.1) : null,
-                    ),
-                  ),
-                ),
-                Expanded(child: notationPanel),
-                const SymbolPalette(),
-              ],
-            );
-
-            final statusStrip = _StatusStrip(
-              horizontalPadding: isLandscape ? 0 : horizontalPadding,
-              symbolType: selected == null ? 'None' : selected is Note ? 'Note' : 'Rest',
-              pitch: selected is Note ? selected.pitch : '—',
-              durationType: selected == null
-                  ? '—'
-                  : selected is Note
-                      ? selected.type
-                      : (selected as Rest).type,
-              measure: _editorState.selectedMeasureIndex == null
-                  ? '—'
-                  : (_editorState.selectedMeasureIndex! + 1).toString(),
-              onPrevMeasure: selectedMeasureIndex > 0
-                  ? () => _updateState(
-                        (s) => s.copyWith(
-                          selectedPartIndex: 0,
-                          selectedMeasureIndex: selectedMeasureIndex - 1,
-                          selectedSymbolIndex: null,
-                          selectedSymbol: null,
-                        ),
-                      )
-                  : null,
-              onNextMeasure: selectedMeasureIndex < measureCount - 1
-                  ? () => _updateState(
-                        (s) => s.copyWith(
-                          selectedPartIndex: 0,
-                          selectedMeasureIndex: selectedMeasureIndex + 1,
-                          selectedSymbolIndex: null,
-                          selectedSymbol: null,
-                        ),
-                      )
-                  : null,
-            );
-
-            final actionBar = _EditorActionBar(
-              horizontalPadding: isLandscape ? 0 : horizontalPadding,
+            final inspectorPanel = _InspectorPanel(
+              isLandscape: isLandscape,
+              selected: selected,
               hasSelection: hasSelection,
               hasMeasureContext: hasMeasureContext,
+              selectedMeasureIndex: selectedMeasureIndex,
+              measureCount: measureCount,
               canUndo: _editorState.canUndo,
               canRedo: _editorState.canRedo,
+              onPrevMeasure: selectedMeasureIndex > 0
+                  ? () => _updateState((s) => s.copyWith(
+                        selectedPartIndex: 0,
+                        selectedMeasureIndex: selectedMeasureIndex - 1,
+                        selectedSymbolIndex: null,
+                        selectedSymbol: null,
+                      ))
+                  : null,
+              onNextMeasure: selectedMeasureIndex < measureCount - 1
+                  ? () => _updateState((s) => s.copyWith(
+                        selectedPartIndex: 0,
+                        selectedMeasureIndex: selectedMeasureIndex + 1,
+                        selectedSymbolIndex: null,
+                        selectedSymbol: null,
+                      ))
+                  : null,
               onMoveUp: () => _updateState((s) => s.moveSelectedSymbolUp()),
               onMoveDown: () => _updateState((s) => s.moveSelectedSymbolDown()),
               onWhole: () => _updateState((s) => s.setSelectedDuration(wholeDuration)),
@@ -276,10 +236,8 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
               onInsertNote: () => _updateState((s) => s.insertNoteAfterSelection()),
               onInsertRest: () => _updateState((s) => s.insertRestAfterSelection()),
               onDelete: () => _updateState((s) => s.deleteSelectedSymbol()),
-              onMoveToPrevMeasure: () =>
-                  _updateState((s) => s.moveSelectedSymbolToMeasureOffset(-1)),
-              onMoveToNextMeasure: () =>
-                  _updateState((s) => s.moveSelectedSymbolToMeasureOffset(1)),
+              onMoveToPrev: () => _updateState((s) => s.moveSelectedSymbolToMeasureOffset(-1)),
+              onMoveToNext: () => _updateState((s) => s.moveSelectedSymbolToMeasureOffset(1)),
               onUndo: () => _updateState((s) => s.applyUndo()),
               onRedo: () => _updateState((s) => s.applyRedo()),
             );
@@ -287,41 +245,52 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
             return Column(
               children: [
                 _EditorHeader(
-                  title: _editorState.score.title.isEmpty ? 'Untitled Score' : _editorState.score.title,
+                  title: _editorState.score.title.isEmpty
+                      ? 'Untitled Score'
+                      : _editorState.score.title,
                   hasUnsavedChanges: _editorState.hasUnsavedChanges,
-                  horizontalPadding: horizontalPadding,
+                  canUndo: _editorState.canUndo,
+                  canRedo: _editorState.canRedo,
                   onBack: () => Navigator.of(context).maybePop(),
+                  onUndo: () => _updateState((s) => s.applyUndo()),
+                  onRedo: () => _updateState((s) => s.applyRedo()),
                 ),
                 Expanded(
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
-                    child: isLandscape
-                        ? Row(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: [
-                              Expanded(child: notationWithPalette),
-                              const SizedBox(width: 12),
-                              SizedBox(
-                                width: controlPanelWidth,
-                                child: SingleChildScrollView(
-                                  child: Column(
-                                    children: [
-                                      statusStrip,
-                                      actionBar,
-                                    ],
-                                  ),
-                                ),
+                  child: isLandscape
+                      ? Row(
+                          children: [
+                            Expanded(
+                              child: Padding(
+                                padding: const EdgeInsets.fromLTRB(12, 0, 6, 12),
+                                child: notationArea,
                               ),
-                            ],
-                          )
-                        : Column(
-                            children: [
-                              Expanded(child: notationWithPalette),
-                              statusStrip,
-                              actionBar,
-                            ],
-                          ),
-                  ),
+                            ),
+                            SizedBox(
+                              width: (constraints.maxWidth * 0.3).clamp(260.0, 320.0),
+                              child: Padding(
+                                padding: const EdgeInsets.fromLTRB(6, 0, 12, 12),
+                                child: inspectorPanel,
+                              ),
+                            ),
+                          ],
+                        )
+                      : Column(
+                          children: [
+                            Expanded(
+                              child: Padding(
+                                padding: const EdgeInsets.fromLTRB(12, 0, 12, 0),
+                                child: notationArea,
+                              ),
+                            ),
+                            SizedBox(
+                              height: (constraints.maxHeight * 0.36).clamp(200.0, 280.0),
+                              child: Padding(
+                                padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                                child: inspectorPanel,
+                              ),
+                            ),
+                          ],
+                        ),
                 ),
               ],
             );
@@ -332,252 +301,415 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Header
+// ---------------------------------------------------------------------------
+
 class _EditorHeader extends StatelessWidget {
   const _EditorHeader({
     required this.title,
     required this.hasUnsavedChanges,
-    required this.horizontalPadding,
+    required this.canUndo,
+    required this.canRedo,
     required this.onBack,
+    required this.onUndo,
+    required this.onRedo,
   });
 
   final String title;
   final bool hasUnsavedChanges;
-  final double horizontalPadding;
+  final bool canUndo;
+  final bool canRedo;
   final VoidCallback onBack;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.fromLTRB(horizontalPadding, 12, horizontalPadding, 8),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-        decoration: BoxDecoration(
-          color: AppColors.surface,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: AppColors.border),
-        ),
-        child: Row(
-          children: [
-            IconButton(
-              onPressed: onBack,
-              icon: const Icon(Icons.arrow_back_ios_new, size: 16),
-              color: AppColors.textPrimary,
-              tooltip: 'Back',
-            ),
-            const SizedBox(width: 4),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    hasUnsavedChanges ? '$title *' : title,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      color: AppColors.textPrimary,
-                      fontSize: 18,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  const SizedBox(height: 2),
-                  const Text(
-                    'Editor Workspace',
-                    style: TextStyle(
-                      color: AppColors.textSecondary,
-                      fontSize: 12,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            FilledButton.icon(
-              onPressed: () {},
-              icon: const Icon(Icons.save_outlined, size: 18),
-              label: const Text('Save'),
-            ),
-            const SizedBox(width: 8),
-            OutlinedButton.icon(
-              onPressed: () {},
-              icon: const Icon(Icons.ios_share_outlined, size: 16),
-              label: const Text('Export'),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: AppColors.textPrimary,
-                side: const BorderSide(color: AppColors.border),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _StatusStrip extends StatelessWidget {
-  const _StatusStrip({
-    required this.horizontalPadding,
-    required this.symbolType,
-    required this.pitch,
-    required this.durationType,
-    required this.measure,
-    required this.onPrevMeasure,
-    required this.onNextMeasure,
-  });
-
-  final double horizontalPadding;
-  final String symbolType;
-  final String pitch;
-  final String durationType;
-  final String measure;
-  final VoidCallback? onPrevMeasure;
-  final VoidCallback? onNextMeasure;
+  final VoidCallback onUndo;
+  final VoidCallback onRedo;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: EdgeInsets.fromLTRB(horizontalPadding, 8, horizontalPadding, 8),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      decoration: BoxDecoration(
+      height: 56,
+      decoration: const BoxDecoration(
         color: AppColors.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: AppColors.border),
+        border: Border(bottom: BorderSide(color: AppColors.border)),
       ),
-      child: Wrap(
-        spacing: 12,
-        runSpacing: 8,
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Row(
         children: [
-          _StatusItem(label: 'Type', value: symbolType),
-          _StatusItem(label: 'Pitch', value: pitch),
-          _StatusItem(label: 'Duration', value: durationType),
-          _StatusItem(label: 'Measure', value: measure),
-          _StatusNavButton(
-            icon: Icons.chevron_left_rounded,
-            onPressed: onPrevMeasure,
+          IconButton(
+            onPressed: onBack,
+            icon: const Icon(Icons.arrow_back_ios_new_rounded, size: 16),
+            color: AppColors.textPrimary,
+            tooltip: 'Back',
           ),
-          _StatusNavButton(
-            icon: Icons.chevron_right_rounded,
-            onPressed: onNextMeasure,
+          const SizedBox(width: 4),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: AppColors.textPrimary,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                    if (hasUnsavedChanges) ...[
+                      const SizedBox(width: 6),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: AppColors.accent.withValues(alpha: 0.18),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: const Text(
+                          'Unsaved',
+                          style: TextStyle(
+                            color: AppColors.accent,
+                            fontSize: 10,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+                const Text(
+                  'Score Editor',
+                  style: TextStyle(color: AppColors.textSecondary, fontSize: 10),
+                ),
+              ],
+            ),
           ),
+          _HeaderIconButton(
+            icon: Icons.undo_rounded,
+            tooltip: 'Undo',
+            enabled: canUndo,
+            onPressed: onUndo,
+          ),
+          _HeaderIconButton(
+            icon: Icons.redo_rounded,
+            tooltip: 'Redo',
+            enabled: canRedo,
+            onPressed: onRedo,
+          ),
+          const SizedBox(width: 6),
+          FilledButton.icon(
+            onPressed: () {},
+            icon: const Icon(Icons.save_rounded, size: 15),
+            label: const Text('Save', style: TextStyle(fontSize: 13)),
+            style: FilledButton.styleFrom(
+              minimumSize: const Size(0, 34),
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+            ),
+          ),
+          const SizedBox(width: 4),
         ],
       ),
     );
   }
 }
 
-class _StatusNavButton extends StatelessWidget {
-  const _StatusNavButton({required this.icon, required this.onPressed});
+class _HeaderIconButton extends StatelessWidget {
+  const _HeaderIconButton({
+    required this.icon,
+    required this.tooltip,
+    required this.enabled,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final bool enabled;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: enabled ? onPressed : null,
+      icon: Icon(icon, size: 18),
+      color: enabled ? AppColors.textPrimary : AppColors.textSecondary.withValues(alpha: 0.4),
+      tooltip: tooltip,
+      visualDensity: VisualDensity.compact,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Notation area (canvas + palette + floating controls)
+// ---------------------------------------------------------------------------
+
+class _NotationArea extends StatelessWidget {
+  const _NotationArea({
+    required this.editorState,
+    required this.canvasZoom,
+    required this.insertMode,
+    required this.insertSymbolType,
+    required this.onZoomIn,
+    required this.onZoomOut,
+    required this.onToggleInsertMode,
+    required this.onPaletteTypeTap,
+    required this.onSymbolTap,
+    required this.onInsertTap,
+    required this.onSymbolReorder,
+    required this.onExternalDrop,
+  });
+
+  final EditorState editorState;
+  final double canvasZoom;
+  final bool insertMode;
+  final PaletteSymbolType? insertSymbolType;
+  final VoidCallback? onZoomIn;
+  final VoidCallback? onZoomOut;
+  final VoidCallback onToggleInsertMode;
+  final ValueChanged<PaletteSymbolType> onPaletteTypeTap;
+  final ValueChanged<NotationSymbolTarget?> onSymbolTap;
+  final ValueChanged<NotationInsertTarget?> onInsertTap;
+  final ValueChanged<NotationSymbolReorder> onSymbolReorder;
+  final void Function(NotationInsertTarget, Object) onExternalDrop;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: Stack(
+            children: [
+              // Canvas
+              Positioned.fill(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: AppColors.surface,
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: AppColors.border),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(11),
+                    child: SingleChildScrollView(
+                      child: Padding(
+                        padding: const EdgeInsets.all(8),
+                        child: ScoreNotationViewer(
+                          score: editorState.score,
+                          minMeasureWidth: 220 * canvasZoom,
+                          selectedMeasureIndex: editorState.selectedMeasureIndex,
+                          selectedSymbolIndex: editorState.selectedSymbolIndex,
+                          insertMode: insertMode,
+                          canAcceptExternalDrop: (data) => data is PaletteDragData,
+                          onExternalDrop: onExternalDrop,
+                          onSymbolTap: insertMode ? null : onSymbolTap,
+                          onInsertTap: insertMode ? onInsertTap : null,
+                          onSymbolReorder: onSymbolReorder,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              // Floating controls overlay
+              Positioned(
+                right: 8,
+                bottom: 8,
+                child: _FloatingControls(
+                  zoomPercent: (canvasZoom * 100).round(),
+                  insertMode: insertMode,
+                  onZoomIn: onZoomIn,
+                  onZoomOut: onZoomOut,
+                  onToggleInsertMode: onToggleInsertMode,
+                ),
+              ),
+              // Insert mode banner
+              if (insertMode)
+                Positioned(
+                  top: 8,
+                  left: 0,
+                  right: 0,
+                  child: Center(
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+                      decoration: BoxDecoration(
+                        color: AppColors.accent.withValues(alpha: 0.18),
+                        borderRadius: BorderRadius.circular(20),
+                        border: Border.all(color: AppColors.accent.withValues(alpha: 0.5)),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.edit_rounded, size: 12, color: AppColors.accent),
+                          const SizedBox(width: 5),
+                          Text(
+                            insertSymbolType != null
+                                ? 'Insert mode — tap to place ${_paletteTypeLabel(insertSymbolType!)}'
+                                : 'Insert mode — select a symbol from palette',
+                            style: const TextStyle(
+                              color: AppColors.accent,
+                              fontSize: 11,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        SymbolPalette(
+          selectedType: insertMode ? insertSymbolType : null,
+          onTypeTap: onPaletteTypeTap,
+        ),
+      ],
+    );
+  }
+
+  String _paletteTypeLabel(PaletteSymbolType type) {
+    return switch (type) {
+      PaletteSymbolType.wholeNote => 'whole note',
+      PaletteSymbolType.halfNote => 'half note',
+      PaletteSymbolType.quarterNote => 'quarter note',
+      PaletteSymbolType.eighthNote => 'eighth note',
+      PaletteSymbolType.wholeRest => 'whole rest',
+      PaletteSymbolType.halfRest => 'half rest',
+      PaletteSymbolType.quarterRest => 'quarter rest',
+    };
+  }
+}
+
+class _FloatingControls extends StatelessWidget {
+  const _FloatingControls({
+    required this.zoomPercent,
+    required this.insertMode,
+    required this.onZoomIn,
+    required this.onZoomOut,
+    required this.onToggleInsertMode,
+  });
+
+  final int zoomPercent;
+  final bool insertMode;
+  final VoidCallback? onZoomIn;
+  final VoidCallback? onZoomOut;
+  final VoidCallback onToggleInsertMode;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        // Mode toggle
+        GestureDetector(
+          onTap: onToggleInsertMode,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 180),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: insertMode
+                  ? AppColors.accent.withValues(alpha: 0.2)
+                  : AppColors.surface.withValues(alpha: 0.9),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(
+                color: insertMode ? AppColors.accent : AppColors.border,
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  insertMode ? Icons.edit_rounded : Icons.touch_app_rounded,
+                  size: 13,
+                  color: insertMode ? AppColors.accent : AppColors.textSecondary,
+                ),
+                const SizedBox(width: 5),
+                Text(
+                  insertMode ? 'Insert' : 'Select',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: insertMode ? AppColors.accent : AppColors.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 6),
+        // Zoom pill
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+          decoration: BoxDecoration(
+            color: AppColors.surface.withValues(alpha: 0.9),
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: AppColors.border),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _ZoomButton(icon: Icons.remove_rounded, onPressed: onZoomOut),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 6),
+                child: Text(
+                  '$zoomPercent%',
+                  style: const TextStyle(
+                    fontSize: 11,
+                    color: AppColors.textSecondary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              _ZoomButton(icon: Icons.add_rounded, onPressed: onZoomIn),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ZoomButton extends StatelessWidget {
+  const _ZoomButton({required this.icon, required this.onPressed});
 
   final IconData icon;
   final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return OutlinedButton(
-      onPressed: onPressed,
-      style: OutlinedButton.styleFrom(
-        side: const BorderSide(color: AppColors.border),
-        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
-        minimumSize: const Size(32, 32),
-      ),
-      child: Icon(icon, size: 18),
-    );
-  }
-}
-
-class _StatusItem extends StatelessWidget {
-  const _StatusItem({required this.label, required this.value});
-
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      constraints: const BoxConstraints(minWidth: 82),
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-      decoration: BoxDecoration(
-        color: AppColors.surfaceAlt,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label,
-            style: const TextStyle(fontSize: 10, color: AppColors.textSecondary),
-          ),
-          Text(
-            value,
-            style: const TextStyle(
-              color: AppColors.textPrimary,
-              fontSize: 12,
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-        ],
+    return SizedBox(
+      width: 28,
+      height: 28,
+      child: IconButton(
+        onPressed: onPressed,
+        icon: Icon(icon, size: 14),
+        color: onPressed != null ? AppColors.textPrimary : AppColors.textSecondary.withValues(alpha: 0.4),
+        padding: EdgeInsets.zero,
+        visualDensity: VisualDensity.compact,
       ),
     );
   }
 }
 
-class _ZoomControls extends StatelessWidget {
-  const _ZoomControls({
-    required this.zoomPercent,
-    required this.onZoomOut,
-    required this.onZoomIn,
-  });
+// ---------------------------------------------------------------------------
+// Inspector + action panel
+// ---------------------------------------------------------------------------
 
-  final int zoomPercent;
-  final VoidCallback? onZoomOut;
-  final VoidCallback? onZoomIn;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: AppColors.surfaceAlt,
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          IconButton(
-            icon: const Icon(Icons.remove, size: 16),
-            visualDensity: VisualDensity.compact,
-            splashRadius: 14,
-            onPressed: onZoomOut,
-            tooltip: 'Zoom out',
-          ),
-          Text(
-            'Zoom $zoomPercent%',
-            style: const TextStyle(
-              fontSize: 11,
-              color: AppColors.textSecondary,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          IconButton(
-            icon: const Icon(Icons.add, size: 16),
-            visualDensity: VisualDensity.compact,
-            splashRadius: 14,
-            onPressed: onZoomIn,
-            tooltip: 'Zoom in',
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _EditorActionBar extends StatelessWidget {
-  const _EditorActionBar({
-    required this.horizontalPadding,
+class _InspectorPanel extends StatelessWidget {
+  const _InspectorPanel({
+    required this.isLandscape,
+    required this.selected,
     required this.hasSelection,
     required this.hasMeasureContext,
+    required this.selectedMeasureIndex,
+    required this.measureCount,
     required this.canUndo,
     required this.canRedo,
+    required this.onPrevMeasure,
+    required this.onNextMeasure,
     required this.onMoveUp,
     required this.onMoveDown,
     required this.onWhole,
@@ -587,17 +719,22 @@ class _EditorActionBar extends StatelessWidget {
     required this.onInsertNote,
     required this.onInsertRest,
     required this.onDelete,
-    required this.onMoveToPrevMeasure,
-    required this.onMoveToNextMeasure,
+    required this.onMoveToPrev,
+    required this.onMoveToNext,
     required this.onUndo,
     required this.onRedo,
   });
 
-  final double horizontalPadding;
+  final bool isLandscape;
+  final ScoreSymbol? selected;
   final bool hasSelection;
   final bool hasMeasureContext;
+  final int selectedMeasureIndex;
+  final int measureCount;
   final bool canUndo;
   final bool canRedo;
+  final VoidCallback? onPrevMeasure;
+  final VoidCallback? onNextMeasure;
   final VoidCallback onMoveUp;
   final VoidCallback onMoveDown;
   final VoidCallback onWhole;
@@ -607,53 +744,333 @@ class _EditorActionBar extends StatelessWidget {
   final VoidCallback onInsertNote;
   final VoidCallback onInsertRest;
   final VoidCallback onDelete;
-  final VoidCallback onMoveToPrevMeasure;
-  final VoidCallback onMoveToNextMeasure;
+  final VoidCallback onMoveToPrev;
+  final VoidCallback onMoveToNext;
   final VoidCallback onUndo;
   final VoidCallback onRedo;
 
   @override
   Widget build(BuildContext context) {
+    if (isLandscape) {
+      return _LandscapePanel(
+        selected: selected,
+        hasSelection: hasSelection,
+        hasMeasureContext: hasMeasureContext,
+        selectedMeasureIndex: selectedMeasureIndex,
+        measureCount: measureCount,
+        onPrevMeasure: onPrevMeasure,
+        onNextMeasure: onNextMeasure,
+        onMoveUp: onMoveUp,
+        onMoveDown: onMoveDown,
+        onWhole: onWhole,
+        onHalf: onHalf,
+        onQuarter: onQuarter,
+        onEighth: onEighth,
+        onInsertNote: onInsertNote,
+        onInsertRest: onInsertRest,
+        onDelete: onDelete,
+        onMoveToPrev: onMoveToPrev,
+        onMoveToNext: onMoveToNext,
+      );
+    }
+
+    return _PortraitPanel(
+      selected: selected,
+      hasSelection: hasSelection,
+      hasMeasureContext: hasMeasureContext,
+      selectedMeasureIndex: selectedMeasureIndex,
+      measureCount: measureCount,
+      onPrevMeasure: onPrevMeasure,
+      onNextMeasure: onNextMeasure,
+      onMoveUp: onMoveUp,
+      onMoveDown: onMoveDown,
+      onWhole: onWhole,
+      onHalf: onHalf,
+      onQuarter: onQuarter,
+      onEighth: onEighth,
+      onInsertNote: onInsertNote,
+      onInsertRest: onInsertRest,
+      onDelete: onDelete,
+      onMoveToPrev: onMoveToPrev,
+      onMoveToNext: onMoveToNext,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Landscape panel
+// ---------------------------------------------------------------------------
+
+class _LandscapePanel extends StatelessWidget {
+  const _LandscapePanel({
+    required this.selected,
+    required this.hasSelection,
+    required this.hasMeasureContext,
+    required this.selectedMeasureIndex,
+    required this.measureCount,
+    required this.onPrevMeasure,
+    required this.onNextMeasure,
+    required this.onMoveUp,
+    required this.onMoveDown,
+    required this.onWhole,
+    required this.onHalf,
+    required this.onQuarter,
+    required this.onEighth,
+    required this.onInsertNote,
+    required this.onInsertRest,
+    required this.onDelete,
+    required this.onMoveToPrev,
+    required this.onMoveToNext,
+  });
+
+  final ScoreSymbol? selected;
+  final bool hasSelection;
+  final bool hasMeasureContext;
+  final int selectedMeasureIndex;
+  final int measureCount;
+  final VoidCallback? onPrevMeasure;
+  final VoidCallback? onNextMeasure;
+  final VoidCallback onMoveUp;
+  final VoidCallback onMoveDown;
+  final VoidCallback onWhole;
+  final VoidCallback onHalf;
+  final VoidCallback onQuarter;
+  final VoidCallback onEighth;
+  final VoidCallback onInsertNote;
+  final VoidCallback onInsertRest;
+  final VoidCallback onDelete;
+  final VoidCallback onMoveToPrev;
+  final VoidCallback onMoveToNext;
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
-      color: AppColors.surfaceAlt,
-      padding: EdgeInsets.fromLTRB(horizontalPadding, 10, horizontalPadding, 16),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _SelectionCard(
+              selected: selected,
+              hasSelection: hasSelection,
+              selectedMeasureIndex: selectedMeasureIndex,
+              measureCount: measureCount,
+              onPrevMeasure: onPrevMeasure,
+              onNextMeasure: onNextMeasure,
+            ),
+            const SizedBox(height: 14),
+            _ActionSection(
+              label: 'PITCH',
+              children: [
+                _ActionTile(
+                  icon: Icons.keyboard_arrow_up_rounded,
+                  label: 'Up',
+                  onPressed: hasSelection ? onMoveUp : null,
+                ),
+                _ActionTile(
+                  icon: Icons.keyboard_arrow_down_rounded,
+                  label: 'Down',
+                  onPressed: hasSelection ? onMoveDown : null,
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            _ActionSection(
+              label: 'DURATION',
+              children: [
+                _DurationTile(label: 'W', sublabel: 'Whole', onPressed: hasSelection ? onWhole : null),
+                _DurationTile(label: 'H', sublabel: 'Half', onPressed: hasSelection ? onHalf : null),
+                _DurationTile(label: '♩', sublabel: 'Qtr', onPressed: hasSelection ? onQuarter : null),
+                _DurationTile(label: '♪', sublabel: '8th', onPressed: hasSelection ? onEighth : null),
+              ],
+            ),
+            const SizedBox(height: 10),
+            _ActionSection(
+              label: 'MEASURE',
+              children: [
+                _ActionTile(
+                  icon: Icons.skip_previous_rounded,
+                  label: 'Prev',
+                  onPressed: hasSelection ? onMoveToPrev : null,
+                ),
+                _ActionTile(
+                  icon: Icons.skip_next_rounded,
+                  label: 'Next',
+                  onPressed: hasSelection ? onMoveToNext : null,
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            _ActionSection(
+              label: 'INSERT',
+              children: [
+                _ActionTile(
+                  icon: Icons.music_note_rounded,
+                  label: 'Note',
+                  onPressed: hasMeasureContext ? onInsertNote : null,
+                ),
+                _ActionTile(
+                  icon: Icons.horizontal_rule_rounded,
+                  label: 'Rest',
+                  onPressed: hasMeasureContext ? onInsertRest : null,
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            _ActionSection(
+              label: 'EDIT',
+              children: [
+                _ActionTile(
+                  icon: Icons.delete_outline_rounded,
+                  label: 'Delete',
+                  onPressed: hasSelection ? onDelete : null,
+                  danger: true,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Portrait panel
+// ---------------------------------------------------------------------------
+
+class _PortraitPanel extends StatelessWidget {
+  const _PortraitPanel({
+    required this.selected,
+    required this.hasSelection,
+    required this.hasMeasureContext,
+    required this.selectedMeasureIndex,
+    required this.measureCount,
+    required this.onPrevMeasure,
+    required this.onNextMeasure,
+    required this.onMoveUp,
+    required this.onMoveDown,
+    required this.onWhole,
+    required this.onHalf,
+    required this.onQuarter,
+    required this.onEighth,
+    required this.onInsertNote,
+    required this.onInsertRest,
+    required this.onDelete,
+    required this.onMoveToPrev,
+    required this.onMoveToNext,
+  });
+
+  final ScoreSymbol? selected;
+  final bool hasSelection;
+  final bool hasMeasureContext;
+  final int selectedMeasureIndex;
+  final int measureCount;
+  final VoidCallback? onPrevMeasure;
+  final VoidCallback? onNextMeasure;
+  final VoidCallback onMoveUp;
+  final VoidCallback onMoveDown;
+  final VoidCallback onWhole;
+  final VoidCallback onHalf;
+  final VoidCallback onQuarter;
+  final VoidCallback onEighth;
+  final VoidCallback onInsertNote;
+  final VoidCallback onInsertRest;
+  final VoidCallback onDelete;
+  final VoidCallback onMoveToPrev;
+  final VoidCallback onMoveToNext;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+        border: Border.all(color: AppColors.border),
+      ),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            'TOOLS',
-            style: TextStyle(
-              fontSize: 11,
-              color: AppColors.textSecondary,
-              letterSpacing: 1.1,
-              fontWeight: FontWeight.w600,
+          // Drag handle
+          Center(
+            child: Container(
+              margin: const EdgeInsets.only(top: 8),
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppColors.border,
+                borderRadius: BorderRadius.circular(2),
+              ),
             ),
           ),
-          const SizedBox(height: 10),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: [
-              _ActionButton(label: 'Move Up', onPressed: hasSelection ? onMoveUp : null),
-              _ActionButton(label: 'Move Down', onPressed: hasSelection ? onMoveDown : null),
-              _ActionButton(label: 'Whole', onPressed: hasSelection ? onWhole : null),
-              _ActionButton(label: 'Half', onPressed: hasSelection ? onHalf : null),
-              _ActionButton(label: 'Quarter', onPressed: hasSelection ? onQuarter : null),
-              _ActionButton(label: 'Eighth', onPressed: hasSelection ? onEighth : null),
-              _ActionButton(label: 'Insert Note', onPressed: hasMeasureContext ? onInsertNote : null),
-              _ActionButton(label: 'Insert Rest', onPressed: hasMeasureContext ? onInsertRest : null),
-              _ActionButton(label: 'Delete', onPressed: hasSelection ? onDelete : null),
-              _ActionButton(
-                label: 'To Prev Measure',
-                onPressed: hasSelection ? onMoveToPrevMeasure : null,
+          // Selection strip
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+            child: _SelectionCard(
+              selected: selected,
+              hasSelection: hasSelection,
+              selectedMeasureIndex: selectedMeasureIndex,
+              measureCount: measureCount,
+              onPrevMeasure: onPrevMeasure,
+              onNextMeasure: onNextMeasure,
+              compact: true,
+            ),
+          ),
+          const SizedBox(height: 8),
+          // Scrollable action row
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+              child: Row(
+                children: [
+                  _CompactActionGroup(
+                    label: 'PITCH',
+                    children: [
+                      _ActionTile(icon: Icons.keyboard_arrow_up_rounded, label: 'Up', onPressed: hasSelection ? onMoveUp : null, compact: true),
+                      _ActionTile(icon: Icons.keyboard_arrow_down_rounded, label: 'Down', onPressed: hasSelection ? onMoveDown : null, compact: true),
+                    ],
+                  ),
+                  _GroupDivider(),
+                  _CompactActionGroup(
+                    label: 'DURATION',
+                    children: [
+                      _DurationTile(label: 'W', sublabel: 'Whole', onPressed: hasSelection ? onWhole : null, compact: true),
+                      _DurationTile(label: 'H', sublabel: 'Half', onPressed: hasSelection ? onHalf : null, compact: true),
+                      _DurationTile(label: '♩', sublabel: 'Qtr', onPressed: hasSelection ? onQuarter : null, compact: true),
+                      _DurationTile(label: '♪', sublabel: '8th', onPressed: hasSelection ? onEighth : null, compact: true),
+                    ],
+                  ),
+                  _GroupDivider(),
+                  _CompactActionGroup(
+                    label: 'MEASURE',
+                    children: [
+                      _ActionTile(icon: Icons.skip_previous_rounded, label: 'Prev', onPressed: hasSelection ? onMoveToPrev : null, compact: true),
+                      _ActionTile(icon: Icons.skip_next_rounded, label: 'Next', onPressed: hasSelection ? onMoveToNext : null, compact: true),
+                    ],
+                  ),
+                  _GroupDivider(),
+                  _CompactActionGroup(
+                    label: 'INSERT',
+                    children: [
+                      _ActionTile(icon: Icons.music_note_rounded, label: 'Note', onPressed: hasMeasureContext ? onInsertNote : null, compact: true),
+                      _ActionTile(icon: Icons.horizontal_rule_rounded, label: 'Rest', onPressed: hasMeasureContext ? onInsertRest : null, compact: true),
+                    ],
+                  ),
+                  _GroupDivider(),
+                  _CompactActionGroup(
+                    label: 'EDIT',
+                    children: [
+                      _ActionTile(icon: Icons.delete_outline_rounded, label: 'Delete', onPressed: hasSelection ? onDelete : null, compact: true, danger: true),
+                    ],
+                  ),
+                ],
               ),
-              _ActionButton(
-                label: 'To Next Measure',
-                onPressed: hasSelection ? onMoveToNextMeasure : null,
-              ),
-              _ActionButton(label: 'Undo', onPressed: canUndo ? onUndo : null),
-              _ActionButton(label: 'Redo', onPressed: canRedo ? onRedo : null),
-            ],
+            ),
           ),
         ],
       ),
@@ -661,26 +1078,442 @@ class _EditorActionBar extends StatelessWidget {
   }
 }
 
-class _ActionButton extends StatelessWidget {
-  const _ActionButton({required this.label, required this.onPressed});
+class _GroupDivider extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1,
+      height: 52,
+      margin: const EdgeInsets.symmetric(horizontal: 8),
+      color: AppColors.border,
+    );
+  }
+}
+
+class _CompactActionGroup extends StatelessWidget {
+  const _CompactActionGroup({required this.label, required this.children});
 
   final String label;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 9,
+            color: AppColors.textSecondary,
+            letterSpacing: 0.8,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(children: children.map((c) => Padding(padding: const EdgeInsets.only(right: 4), child: c)).toList()),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Selection info card
+// ---------------------------------------------------------------------------
+
+class _SelectionCard extends StatelessWidget {
+  const _SelectionCard({
+    required this.selected,
+    required this.hasSelection,
+    required this.selectedMeasureIndex,
+    required this.measureCount,
+    required this.onPrevMeasure,
+    required this.onNextMeasure,
+    this.compact = false,
+  });
+
+  final ScoreSymbol? selected;
+  final bool hasSelection;
+  final int selectedMeasureIndex;
+  final int measureCount;
+  final VoidCallback? onPrevMeasure;
+  final VoidCallback? onNextMeasure;
+  final bool compact;
+
+  String get _pitchLabel {
+    if (selected is Note) return (selected as Note).pitch;
+    return '—';
+  }
+
+  String get _durationLabel {
+    if (selected is Note) return (selected as Note).type;
+    if (selected is Rest) return (selected as Rest).type;
+    return '—';
+  }
+
+  bool get _isNote => selected is Note;
+  bool get _isRest => selected is Rest;
+
+  @override
+  Widget build(BuildContext context) {
+    if (compact) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: AppColors.surfaceAlt,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: AppColors.border),
+        ),
+        child: Row(
+          children: [
+            if (hasSelection) ...[
+              Container(
+                padding: const EdgeInsets.all(4),
+                decoration: BoxDecoration(
+                  color: AppColors.accent.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(5),
+                ),
+                child: Icon(
+                  _isNote ? Icons.music_note_rounded : Icons.horizontal_rule_rounded,
+                  size: 13,
+                  color: AppColors.accent,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                _pitchLabel,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(width: 6),
+              Text(
+                _durationLabel,
+                style: const TextStyle(color: AppColors.textSecondary, fontSize: 11),
+              ),
+            ] else
+              const Text(
+                'Tap a symbol to select',
+                style: TextStyle(color: AppColors.textSecondary, fontSize: 12),
+              ),
+            const Spacer(),
+            _MeasureNav(
+              selectedMeasureIndex: selectedMeasureIndex,
+              measureCount: measureCount,
+              onPrev: onPrevMeasure,
+              onNext: onNextMeasure,
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceAlt,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text(
+                'SELECTION',
+                style: TextStyle(
+                  fontSize: 10,
+                  color: AppColors.textSecondary,
+                  letterSpacing: 1.0,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const Spacer(),
+              _MeasureNav(
+                selectedMeasureIndex: selectedMeasureIndex,
+                measureCount: measureCount,
+                onPrev: onPrevMeasure,
+                onNext: onNextMeasure,
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          if (hasSelection) ...[
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: BoxDecoration(
+                    color: AppColors.accent.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Icon(
+                    _isNote ? Icons.music_note_rounded : Icons.horizontal_rule_rounded,
+                    size: 16,
+                    color: AppColors.accent,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      _isNote ? _pitchLabel : (_isRest ? 'Rest' : '—'),
+                      style: const TextStyle(
+                        color: AppColors.textPrimary,
+                        fontSize: 18,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    Text(
+                      _durationLabel,
+                      style: const TextStyle(color: AppColors.textSecondary, fontSize: 11),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ] else
+            const Text(
+              'Tap a note or rest to select it',
+              style: TextStyle(color: AppColors.textSecondary, fontSize: 12),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MeasureNav extends StatelessWidget {
+  const _MeasureNav({
+    required this.selectedMeasureIndex,
+    required this.measureCount,
+    required this.onPrev,
+    required this.onNext,
+  });
+
+  final int selectedMeasureIndex;
+  final int measureCount;
+  final VoidCallback? onPrev;
+  final VoidCallback? onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _NavBtn(icon: Icons.chevron_left_rounded, onPressed: onPrev),
+        Container(
+          constraints: const BoxConstraints(minWidth: 42),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(6),
+            border: Border.all(color: AppColors.border),
+          ),
+          child: Text(
+            measureCount > 0 ? 'M ${selectedMeasureIndex + 1}' : '—',
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              fontSize: 11,
+              color: AppColors.textPrimary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        _NavBtn(icon: Icons.chevron_right_rounded, onPressed: onNext),
+      ],
+    );
+  }
+}
+
+class _NavBtn extends StatelessWidget {
+  const _NavBtn({required this.icon, required this.onPressed});
+
+  final IconData icon;
   final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
-    final enabled = onPressed != null;
-    return OutlinedButton(
-      onPressed: onPressed,
-      style: OutlinedButton.styleFrom(
-        backgroundColor: enabled ? AppColors.surface : AppColors.surfaceAlt,
-        foregroundColor: enabled ? AppColors.textPrimary : AppColors.textSecondary,
-        side: BorderSide(
-          color: enabled ? AppColors.accent.withValues(alpha: 0.6) : AppColors.border,
-        ),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+    return SizedBox(
+      width: 28,
+      height: 28,
+      child: IconButton(
+        onPressed: onPressed,
+        icon: Icon(icon, size: 16),
+        padding: EdgeInsets.zero,
+        color: onPressed != null ? AppColors.textPrimary : AppColors.textSecondary.withValues(alpha: 0.3),
+        visualDensity: VisualDensity.compact,
       ),
-      child: Text(label),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Action section / tiles
+// ---------------------------------------------------------------------------
+
+class _ActionSection extends StatelessWidget {
+  const _ActionSection({required this.label, required this.children});
+
+  final String label;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 10,
+            color: AppColors.textSecondary,
+            letterSpacing: 0.8,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Wrap(spacing: 6, runSpacing: 6, children: children),
+      ],
+    );
+  }
+}
+
+class _ActionTile extends StatelessWidget {
+  const _ActionTile({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    this.danger = false,
+    this.compact = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback? onPressed;
+  final bool danger;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = onPressed != null;
+    final activeColor = danger ? const Color(0xFFEF4444) : AppColors.textPrimary;
+    final iconColor = enabled
+        ? (danger ? const Color(0xFFEF4444) : AppColors.textPrimary)
+        : AppColors.textSecondary.withValues(alpha: 0.35);
+
+    return Tooltip(
+      message: label,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(8),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          width: compact ? 46 : 56,
+          padding: EdgeInsets.symmetric(
+            horizontal: compact ? 4 : 6,
+            vertical: compact ? 5 : 7,
+          ),
+          decoration: BoxDecoration(
+            color: enabled ? AppColors.surface : AppColors.surfaceAlt,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: enabled
+                  ? (danger
+                      ? const Color(0xFFEF4444).withValues(alpha: 0.4)
+                      : AppColors.border)
+                  : AppColors.border.withValues(alpha: 0.4),
+            ),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: compact ? 16 : 18, color: iconColor),
+              SizedBox(height: compact ? 2 : 3),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 9,
+                  color: enabled ? activeColor.withValues(alpha: 0.7) : AppColors.textSecondary.withValues(alpha: 0.3),
+                  fontWeight: FontWeight.w500,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DurationTile extends StatelessWidget {
+  const _DurationTile({
+    required this.label,
+    required this.sublabel,
+    required this.onPressed,
+    this.compact = false,
+  });
+
+  final String label;
+  final String sublabel;
+  final VoidCallback? onPressed;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = onPressed != null;
+
+    return Tooltip(
+      message: sublabel,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(8),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          width: compact ? 46 : 52,
+          padding: EdgeInsets.symmetric(
+            horizontal: compact ? 4 : 6,
+            vertical: compact ? 5 : 7,
+          ),
+          decoration: BoxDecoration(
+            color: enabled ? AppColors.surface : AppColors.surfaceAlt,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: enabled ? AppColors.border : AppColors.border.withValues(alpha: 0.4),
+            ),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: compact ? 14 : 16,
+                  color: enabled ? AppColors.textPrimary : AppColors.textSecondary.withValues(alpha: 0.35),
+                  fontWeight: FontWeight.w700,
+                  height: 1.2,
+                ),
+              ),
+              SizedBox(height: compact ? 1 : 2),
+              Text(
+                sublabel,
+                style: TextStyle(
+                  fontSize: 9,
+                  color: enabled ? AppColors.textSecondary.withValues(alpha: 0.7) : AppColors.textSecondary.withValues(alpha: 0.3),
+                  fontWeight: FontWeight.w500,
+                ),
+                maxLines: 1,
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -7,6 +7,7 @@ import 'package:note_vision/core/theme/responsive_layout.dart';
 import 'package:note_vision/core/widgets/score_notation_viewer.dart';
 import 'package:note_vision/features/editor/domain/editor_actions.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
+import 'package:note_vision/features/editor/presentation/widgets/symbol_palette.dart';
 
 class EditorShellArgs {
   const EditorShellArgs({required this.score, required this.initialState});
@@ -144,6 +145,14 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
               ),
             );
 
+
+            final notationWithPalette = Column(
+              children: [
+                Expanded(child: notationPanel),
+                const SymbolPalette(),
+              ],
+            );
+
             final statusStrip = _StatusStrip(
               horizontalPadding: isLandscape ? 0 : horizontalPadding,
               symbolType: selected == null ? 'None' : selected is Note ? 'Note' : 'Rest',
@@ -216,7 +225,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                         ? Row(
                             crossAxisAlignment: CrossAxisAlignment.stretch,
                             children: [
-                              Expanded(child: notationPanel),
+                              Expanded(child: notationWithPalette),
                               const SizedBox(width: 12),
                               SizedBox(
                                 width: controlPanelWidth,
@@ -233,7 +242,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                           )
                         : Column(
                             children: [
-                              Expanded(child: notationPanel),
+                              Expanded(child: notationWithPalette),
                               statusStrip,
                               actionBar,
                             ],

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -31,6 +31,7 @@ class EditorShellScreen extends StatefulWidget {
 
 class _EditorShellScreenState extends State<EditorShellScreen> {
   late EditorState _editorState;
+  double _canvasZoom = 1.0;
 
   @override
   void initState() {
@@ -145,6 +146,12 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
     );
   }
 
+  void _changeZoom(double delta) {
+    setState(() {
+      _canvasZoom = (_canvasZoom + delta).clamp(0.75, 2.0).toDouble();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final selected = _editorState.selectedSymbol;
@@ -175,6 +182,7 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                   padding: const EdgeInsets.all(8),
                   child: ScoreNotationViewer(
                     score: _editorState.score,
+                    minMeasureWidth: 220 * _canvasZoom,
                     selectedMeasureIndex: _editorState.selectedMeasureIndex,
                     selectedSymbolIndex: _editorState.selectedSymbolIndex,
                     canAcceptExternalDrop: (data) => data is PaletteDragData,
@@ -203,6 +211,17 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
 
             final notationWithPalette = Column(
               children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 8, 8, 6),
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: _ZoomControls(
+                      zoomPercent: (_canvasZoom * 100).round(),
+                      onZoomOut: _canvasZoom > 0.75 ? () => _changeZoom(-0.1) : null,
+                      onZoomIn: _canvasZoom < 2.0 ? () => _changeZoom(0.1) : null,
+                    ),
+                  ),
+                ),
                 Expanded(child: notationPanel),
                 const SymbolPalette(),
               ],
@@ -494,6 +513,57 @@ class _StatusItem extends StatelessWidget {
               fontSize: 12,
               fontWeight: FontWeight.w700,
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ZoomControls extends StatelessWidget {
+  const _ZoomControls({
+    required this.zoomPercent,
+    required this.onZoomOut,
+    required this.onZoomIn,
+  });
+
+  final int zoomPercent;
+  final VoidCallback? onZoomOut;
+  final VoidCallback? onZoomIn;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceAlt,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.remove, size: 16),
+            visualDensity: VisualDensity.compact,
+            splashRadius: 14,
+            onPressed: onZoomOut,
+            tooltip: 'Zoom out',
+          ),
+          Text(
+            'Zoom $zoomPercent%',
+            style: const TextStyle(
+              fontSize: 11,
+              color: AppColors.textSecondary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.add, size: 16),
+            visualDensity: VisualDensity.compact,
+            splashRadius: 14,
+            onPressed: onZoomIn,
+            tooltip: 'Zoom in',
           ),
         ],
       ),

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:note_vision/core/models/note.dart';
 import 'package:note_vision/core/models/rest.dart';
 import 'package:note_vision/core/models/score.dart';
+import 'package:note_vision/core/models/score_symbol.dart';
+import 'package:note_vision/core/widgets/score_notation/score_notation_painter.dart';
 import 'package:note_vision/core/theme/app_theme.dart';
 import 'package:note_vision/core/theme/responsive_layout.dart';
 import 'package:note_vision/core/widgets/score_notation_viewer.dart';
@@ -71,6 +73,57 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
     });
   }
 
+  void _onPaletteDrop(NotationInsertTarget target, Object data) {
+    if (data is! PaletteDragData) return;
+    final symbol = _buildDroppedSymbol(data.type, target);
+    _updateState(
+      (state) => state.insertSymbolAtMeasureIndex(
+        measureIndex: target.measureIndex,
+        insertIndex: target.insertIndex,
+        symbol: symbol,
+      ),
+    );
+  }
+
+  ScoreSymbol _buildDroppedSymbol(PaletteSymbolType type, NotationInsertTarget target) {
+    switch (type) {
+      case PaletteSymbolType.wholeNote:
+        return Note(
+          step: target.step,
+          octave: target.octave.clamp(1, 7).toInt(),
+          duration: 4,
+          type: 'whole',
+        );
+      case PaletteSymbolType.halfNote:
+        return Note(
+          step: target.step,
+          octave: target.octave.clamp(1, 7).toInt(),
+          duration: 2,
+          type: 'half',
+        );
+      case PaletteSymbolType.quarterNote:
+        return Note(
+          step: target.step,
+          octave: target.octave.clamp(1, 7).toInt(),
+          duration: 1,
+          type: 'quarter',
+        );
+      case PaletteSymbolType.eighthNote:
+        return Note(
+          step: target.step,
+          octave: target.octave.clamp(1, 7).toInt(),
+          duration: 1,
+          type: 'eighth',
+        );
+      case PaletteSymbolType.wholeRest:
+        return const Rest(duration: 4, type: 'whole');
+      case PaletteSymbolType.halfRest:
+        return const Rest(duration: 2, type: 'half');
+      case PaletteSymbolType.quarterRest:
+        return const Rest(duration: 1, type: 'quarter');
+    }
+  }
+
   EditorState _withDefaultMeasureContext(EditorState state) {
     if (state.selectedPartIndex != null && state.selectedMeasureIndex != null) {
       return state;
@@ -124,6 +177,8 @@ class _EditorShellScreenState extends State<EditorShellScreen> {
                     score: _editorState.score,
                     selectedMeasureIndex: _editorState.selectedMeasureIndex,
                     selectedSymbolIndex: _editorState.selectedSymbolIndex,
+                    canAcceptExternalDrop: (data) => data is PaletteDragData,
+                    onExternalDrop: _onPaletteDrop,
                     onSymbolTap: (target) {
                       if (target == null) {
                         _updateState((state) => _clearSymbolSelection(state));

--- a/lib/features/editor/presentation/widgets/symbol_palette.dart
+++ b/lib/features/editor/presentation/widgets/symbol_palette.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:note_vision/core/theme/app_theme.dart';
 
-const Color _paletteBackground = Color(0xFF1A1A1A);
-const Color _paletteTopBorder = Color(0xFF2C2C2C);
-const Color _paletteLabelColor = Color(0xFF8A8A8A);
 const Color _paletteSymbolColor = Color(0xFFE6E6E6);
+const Color _paletteSymbolSelected = Color(0xFFD4A96A);
 
 enum PaletteSymbolType {
   wholeNote,
@@ -22,7 +21,14 @@ class PaletteDragData {
 }
 
 class SymbolPalette extends StatelessWidget {
-  const SymbolPalette({super.key});
+  const SymbolPalette({
+    super.key,
+    this.selectedType,
+    this.onTypeTap,
+  });
+
+  final PaletteSymbolType? selectedType;
+  final ValueChanged<PaletteSymbolType>? onTypeTap;
 
   static const List<_PaletteItemData> _items = [
     _PaletteItemData(type: PaletteSymbolType.wholeNote, label: 'Whole'),
@@ -38,22 +44,24 @@ class SymbolPalette extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       key: const ValueKey('symbol-palette'),
-      height: 100,
+      height: 88,
       decoration: const BoxDecoration(
-        color: _paletteBackground,
-        border: Border(
-          top: BorderSide(color: _paletteTopBorder, width: 1),
-        ),
+        color: AppColors.surfaceAlt,
+        border: Border(top: BorderSide(color: AppColors.border)),
       ),
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
         child: Row(
           children: _items
               .map(
                 (item) => Padding(
-                  padding: const EdgeInsets.only(right: 12),
-                  child: _PaletteDraggableItem(item: item),
+                  padding: const EdgeInsets.only(right: 8),
+                  child: _PaletteDraggableItem(
+                    item: item,
+                    isSelected: selectedType == item.type,
+                    onTap: onTypeTap != null ? () => onTypeTap!(item.type) : null,
+                  ),
                 ),
               )
               .toList(growable: false),
@@ -64,51 +72,73 @@ class SymbolPalette extends StatelessWidget {
 }
 
 class _PaletteDraggableItem extends StatelessWidget {
-  const _PaletteDraggableItem({required this.item});
+  const _PaletteDraggableItem({
+    required this.item,
+    required this.isSelected,
+    this.onTap,
+  });
 
   final _PaletteItemData item;
+  final bool isSelected;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
-    final core = _PaletteVisual(item: item);
+    final core = _PaletteVisual(item: item, isSelected: isSelected);
     return LongPressDraggable<PaletteDragData>(
       data: PaletteDragData(type: item.type),
       feedback: Material(
         color: Colors.transparent,
-        child: Transform.scale(
-          scale: 1.5,
-          child: core,
-        ),
+        child: Transform.scale(scale: 1.5, child: core),
       ),
       childWhenDragging: Opacity(opacity: 0.28, child: core),
-      child: core,
+      child: GestureDetector(
+        onTap: onTap,
+        child: core,
+      ),
     );
   }
 }
 
 class _PaletteVisual extends StatelessWidget {
-  const _PaletteVisual({required this.item});
+  const _PaletteVisual({required this.item, required this.isSelected});
 
   final _PaletteItemData item;
+  final bool isSelected;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: 64,
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 150),
+      width: 58,
+      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+      decoration: BoxDecoration(
+        color: isSelected
+            ? AppColors.accent.withValues(alpha: 0.15)
+            : AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: isSelected ? AppColors.accent : AppColors.border,
+          width: isSelected ? 1.5 : 1.0,
+        ),
+      ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           CustomPaint(
-            size: const Size(32, 42),
-            painter: _PaletteSymbolPainter(type: item.type),
+            size: const Size(28, 34),
+            painter: _PaletteSymbolPainter(
+              type: item.type,
+              color: isSelected ? _paletteSymbolSelected : _paletteSymbolColor,
+            ),
           ),
-          const SizedBox(height: 4),
+          const SizedBox(height: 3),
           Text(
             item.label,
-            style: const TextStyle(
-              fontSize: 10,
-              color: _paletteLabelColor,
-              fontWeight: FontWeight.w500,
+            style: TextStyle(
+              fontSize: 9,
+              color: isSelected ? AppColors.accent : AppColors.textSecondary,
+              fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
             ),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
@@ -120,14 +150,15 @@ class _PaletteVisual extends StatelessWidget {
 }
 
 class _PaletteSymbolPainter extends CustomPainter {
-  const _PaletteSymbolPainter({required this.type});
+  const _PaletteSymbolPainter({required this.type, required this.color});
 
   final PaletteSymbolType type;
+  final Color color;
 
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
-      ..color = _paletteSymbolColor
+      ..color = color
       ..style = PaintingStyle.stroke
       ..strokeWidth = 2.0
       ..strokeCap = StrokeCap.round;
@@ -168,7 +199,7 @@ class _PaletteSymbolPainter extends CustomPainter {
       canvas.drawOval(
         headRect,
         Paint()
-          ..color = _paletteSymbolColor
+          ..color = color
           ..style = PaintingStyle.fill,
       );
     } else {
@@ -192,24 +223,14 @@ class _PaletteSymbolPainter extends CustomPainter {
   void _drawWholeRest(Canvas canvas, Paint paint, Size size) {
     final lineY = size.height * 0.45;
     final barRect = Rect.fromLTWH(size.width * 0.28, lineY, size.width * 0.44, 6);
-    canvas.drawRect(
-      barRect,
-      Paint()
-        ..color = _paletteSymbolColor
-        ..style = PaintingStyle.fill,
-    );
+    canvas.drawRect(barRect, Paint()..color = color..style = PaintingStyle.fill);
     canvas.drawLine(Offset(size.width * 0.2, lineY), Offset(size.width * 0.8, lineY), paint);
   }
 
   void _drawHalfRest(Canvas canvas, Paint paint, Size size) {
     final lineY = size.height * 0.52;
     final barRect = Rect.fromLTWH(size.width * 0.28, lineY - 6, size.width * 0.44, 6);
-    canvas.drawRect(
-      barRect,
-      Paint()
-        ..color = _paletteSymbolColor
-        ..style = PaintingStyle.fill,
-    );
+    canvas.drawRect(barRect, Paint()..color = color..style = PaintingStyle.fill);
     canvas.drawLine(Offset(size.width * 0.2, lineY), Offset(size.width * 0.8, lineY), paint);
   }
 
@@ -224,7 +245,8 @@ class _PaletteSymbolPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant _PaletteSymbolPainter oldDelegate) => oldDelegate.type != type;
+  bool shouldRepaint(covariant _PaletteSymbolPainter oldDelegate) =>
+      oldDelegate.type != type || oldDelegate.color != color;
 }
 
 class _PaletteItemData {

--- a/lib/features/editor/presentation/widgets/symbol_palette.dart
+++ b/lib/features/editor/presentation/widgets/symbol_palette.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+
+const Color _paletteBackground = Color(0xFF1A1A1A);
+const Color _paletteTopBorder = Color(0xFF2C2C2C);
+const Color _paletteLabelColor = Color(0xFF8A8A8A);
+const Color _paletteSymbolColor = Color(0xFFE6E6E6);
+
+enum PaletteSymbolType {
+  wholeNote,
+  halfNote,
+  quarterNote,
+  eighthNote,
+  wholeRest,
+  halfRest,
+  quarterRest,
+}
+
+class PaletteDragData {
+  const PaletteDragData({required this.type});
+
+  final PaletteSymbolType type;
+}
+
+class SymbolPalette extends StatelessWidget {
+  const SymbolPalette({super.key});
+
+  static const List<_PaletteItemData> _items = [
+    _PaletteItemData(type: PaletteSymbolType.wholeNote, label: 'Whole'),
+    _PaletteItemData(type: PaletteSymbolType.halfNote, label: 'Half'),
+    _PaletteItemData(type: PaletteSymbolType.quarterNote, label: 'Quarter'),
+    _PaletteItemData(type: PaletteSymbolType.eighthNote, label: 'Eighth'),
+    _PaletteItemData(type: PaletteSymbolType.wholeRest, label: 'W Rest'),
+    _PaletteItemData(type: PaletteSymbolType.halfRest, label: 'H Rest'),
+    _PaletteItemData(type: PaletteSymbolType.quarterRest, label: 'Q Rest'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const ValueKey('symbol-palette'),
+      height: 100,
+      decoration: const BoxDecoration(
+        color: _paletteBackground,
+        border: Border(
+          top: BorderSide(color: _paletteTopBorder, width: 1),
+        ),
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        child: Row(
+          children: _items
+              .map(
+                (item) => Padding(
+                  padding: const EdgeInsets.only(right: 12),
+                  child: _PaletteDraggableItem(item: item),
+                ),
+              )
+              .toList(growable: false),
+        ),
+      ),
+    );
+  }
+}
+
+class _PaletteDraggableItem extends StatelessWidget {
+  const _PaletteDraggableItem({required this.item});
+
+  final _PaletteItemData item;
+
+  @override
+  Widget build(BuildContext context) {
+    final core = _PaletteVisual(item: item);
+    return LongPressDraggable<PaletteDragData>(
+      data: PaletteDragData(type: item.type),
+      feedback: Material(
+        color: Colors.transparent,
+        child: Transform.scale(
+          scale: 1.5,
+          child: core,
+        ),
+      ),
+      childWhenDragging: Opacity(opacity: 0.28, child: core),
+      child: core,
+    );
+  }
+}
+
+class _PaletteVisual extends StatelessWidget {
+  const _PaletteVisual({required this.item});
+
+  final _PaletteItemData item;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 64,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CustomPaint(
+            size: const Size(32, 42),
+            painter: _PaletteSymbolPainter(type: item.type),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            item.label,
+            style: const TextStyle(
+              fontSize: 10,
+              color: _paletteLabelColor,
+              fontWeight: FontWeight.w500,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PaletteSymbolPainter extends CustomPainter {
+  const _PaletteSymbolPainter({required this.type});
+
+  final PaletteSymbolType type;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = _paletteSymbolColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0
+      ..strokeCap = StrokeCap.round;
+
+    switch (type) {
+      case PaletteSymbolType.wholeNote:
+        _drawNote(canvas, paint, size, filled: false, withStem: false, withFlag: false);
+      case PaletteSymbolType.halfNote:
+        _drawNote(canvas, paint, size, filled: false, withStem: true, withFlag: false);
+      case PaletteSymbolType.quarterNote:
+        _drawNote(canvas, paint, size, filled: true, withStem: true, withFlag: false);
+      case PaletteSymbolType.eighthNote:
+        _drawNote(canvas, paint, size, filled: true, withStem: true, withFlag: true);
+      case PaletteSymbolType.wholeRest:
+        _drawWholeRest(canvas, paint, size);
+      case PaletteSymbolType.halfRest:
+        _drawHalfRest(canvas, paint, size);
+      case PaletteSymbolType.quarterRest:
+        _drawQuarterRest(canvas, paint, size);
+    }
+  }
+
+  void _drawNote(
+    Canvas canvas,
+    Paint paint,
+    Size size, {
+    required bool filled,
+    required bool withStem,
+    required bool withFlag,
+  }) {
+    final headRect = Rect.fromCenter(
+      center: Offset(size.width * 0.44, size.height * 0.68),
+      width: 14,
+      height: 10,
+    );
+
+    if (filled) {
+      canvas.drawOval(
+        headRect,
+        Paint()
+          ..color = _paletteSymbolColor
+          ..style = PaintingStyle.fill,
+      );
+    } else {
+      canvas.drawOval(headRect, paint);
+    }
+
+    if (!withStem) return;
+
+    final stemStart = Offset(headRect.right - 1, headRect.center.dy);
+    final stemEnd = Offset(stemStart.dx, size.height * 0.2);
+    canvas.drawLine(stemStart, stemEnd, paint);
+
+    if (withFlag) {
+      final path = Path()
+        ..moveTo(stemEnd.dx, stemEnd.dy)
+        ..quadraticBezierTo(stemEnd.dx + 8, stemEnd.dy + 3, stemEnd.dx + 5, stemEnd.dy + 11);
+      canvas.drawPath(path, paint);
+    }
+  }
+
+  void _drawWholeRest(Canvas canvas, Paint paint, Size size) {
+    final lineY = size.height * 0.45;
+    final barRect = Rect.fromLTWH(size.width * 0.28, lineY, size.width * 0.44, 6);
+    canvas.drawRect(
+      barRect,
+      Paint()
+        ..color = _paletteSymbolColor
+        ..style = PaintingStyle.fill,
+    );
+    canvas.drawLine(Offset(size.width * 0.2, lineY), Offset(size.width * 0.8, lineY), paint);
+  }
+
+  void _drawHalfRest(Canvas canvas, Paint paint, Size size) {
+    final lineY = size.height * 0.52;
+    final barRect = Rect.fromLTWH(size.width * 0.28, lineY - 6, size.width * 0.44, 6);
+    canvas.drawRect(
+      barRect,
+      Paint()
+        ..color = _paletteSymbolColor
+        ..style = PaintingStyle.fill,
+    );
+    canvas.drawLine(Offset(size.width * 0.2, lineY), Offset(size.width * 0.8, lineY), paint);
+  }
+
+  void _drawQuarterRest(Canvas canvas, Paint paint, Size size) {
+    final path = Path()
+      ..moveTo(size.width * 0.55, size.height * 0.18)
+      ..lineTo(size.width * 0.38, size.height * 0.38)
+      ..lineTo(size.width * 0.54, size.height * 0.48)
+      ..lineTo(size.width * 0.4, size.height * 0.7)
+      ..lineTo(size.width * 0.56, size.height * 0.82);
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _PaletteSymbolPainter oldDelegate) => oldDelegate.type != type;
+}
+
+class _PaletteItemData {
+  const _PaletteItemData({required this.type, required this.label});
+
+  final PaletteSymbolType type;
+  final String label;
+}

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:note_vision/core/widgets/score_notation/notation_layout.dart';
 import 'package:note_vision/core/widgets/score_notation/score_notation_painter.dart';
 import 'package:note_vision/features/editor/model/editor_state.dart';
 import 'package:note_vision/features/editor/presentation/editor_shell_screen.dart';
+import 'package:note_vision/features/editor/presentation/widgets/symbol_palette.dart';
 
 void main() {
   Score buildScore({bool withSymbols = true}) {
@@ -56,15 +57,38 @@ void main() {
     expect(find.text('Save'), findsOneWidget);
     expect(find.text('Move Up'), findsOneWidget);
     expect(find.text('Move Down'), findsOneWidget);
-    expect(find.text('Whole'), findsOneWidget);
-    expect(find.text('Half'), findsOneWidget);
-    expect(find.text('Quarter'), findsOneWidget);
-    expect(find.text('Eighth'), findsOneWidget);
+    expect(find.text('Whole'), findsWidgets);
+    expect(find.text('Half'), findsWidgets);
+    expect(find.text('Quarter'), findsWidgets);
+    expect(find.text('Eighth'), findsWidgets);
     expect(find.text('Insert Note'), findsOneWidget);
     expect(find.text('Insert Rest'), findsOneWidget);
     expect(find.text('Delete'), findsOneWidget);
     expect(find.text('Undo'), findsOneWidget);
     expect(find.text('Redo'), findsOneWidget);
+  });
+
+  testWidgets('renders draggable symbol palette with seven items', (tester) async {
+    final score = buildScore();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('symbol-palette')), findsOneWidget);
+    expect(find.text('W Rest'), findsOneWidget);
+    expect(find.text('H Rest'), findsOneWidget);
+    expect(find.text('Q Rest'), findsOneWidget);
+
+    final draggables = find.byWidgetPredicate((widget) => widget is LongPressDraggable<PaletteDragData>);
+    expect(draggables, findsNWidgets(7));
   });
 
   testWidgets('keeps insert actions enabled with default measure context', (

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -91,6 +91,85 @@ void main() {
     expect(draggables, findsNWidgets(7));
   });
 
+  testWidgets('dropping palette note inserts by drop and undo restores previous state', (
+    tester,
+  ) async {
+    final score = buildScore(withSymbols: false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+
+    await _dragPaletteItemToNotation(
+      tester,
+      label: 'Quarter',
+      dropOffset: const Offset(88, 92),
+    );
+
+    expect(find.text('Note'), findsOneWidget);
+    expect(find.text('None'), findsNothing);
+
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Undo'));
+    await tester.pumpAndSettle();
+    expect(find.text('None'), findsOneWidget);
+  });
+
+  testWidgets('dropping rest inserts rest and ignores pitch mapping', (tester) async {
+    final score = buildScore(withSymbols: false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+
+    await _dragPaletteItemToNotation(
+      tester,
+      label: 'H Rest',
+      dropOffset: const Offset(106, 68),
+    );
+
+    expect(find.text('Rest'), findsOneWidget);
+    expect(find.text('—'), findsWidgets);
+  });
+
+  testWidgets('dropping outside measure boundary is ignored', (tester) async {
+    final score = buildScore(withSymbols: false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+
+    await _dragPaletteItemToNotation(
+      tester,
+      label: 'Quarter',
+      dropOffset: const Offset(16, 92),
+    );
+
+    expect(find.text('None'), findsOneWidget);
+    expect(find.text('Note'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('keeps insert actions enabled with default measure context', (
     tester,
   ) async {
@@ -263,6 +342,26 @@ void main() {
     expect(symbolLabelRect.left, greaterThan(notationRect.right));
     expect(tester.takeException(), isNull);
   });
+}
+
+Future<void> _dragPaletteItemToNotation(
+  WidgetTester tester, {
+  required String label,
+  required Offset dropOffset,
+}) async {
+  final paletteItem = find.descendant(
+    of: find.byKey(const ValueKey('symbol-palette')),
+    matching: find.text(label),
+  );
+  expect(paletteItem, findsOneWidget);
+
+  final notationOrigin = tester.getTopLeft(find.byType(ScoreNotationViewer));
+  final gesture = await tester.startGesture(tester.getCenter(paletteItem));
+  await tester.pump(kLongPressTimeout + const Duration(milliseconds: 20));
+  await gesture.moveTo(notationOrigin + dropOffset);
+  await tester.pump();
+  await gesture.up();
+  await tester.pumpAndSettle();
 }
 
 Offset _symbolCenterOffset(

--- a/test/features/editor/presentation/editor_shell_screen_test.dart
+++ b/test/features/editor/presentation/editor_shell_screen_test.dart
@@ -66,6 +66,7 @@ void main() {
     expect(find.text('Delete'), findsOneWidget);
     expect(find.text('Undo'), findsOneWidget);
     expect(find.text('Redo'), findsOneWidget);
+    expect(find.text('Zoom 100%'), findsOneWidget);
   });
 
   testWidgets('renders draggable symbol palette with seven items', (tester) async {
@@ -168,6 +169,30 @@ void main() {
     expect(find.text('None'), findsOneWidget);
     expect(find.text('Note'), findsNothing);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('zoom controls update canvas zoom level', (tester) async {
+    final score = buildScore();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditorShellScreen(
+          args: EditorShellArgs(
+            score: score,
+            initialState: EditorState(score: score),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Zoom 100%'), findsOneWidget);
+    await tester.tap(find.byTooltip('Zoom in'));
+    await tester.pumpAndSettle();
+    expect(find.text('Zoom 110%'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Zoom out'));
+    await tester.pumpAndSettle();
+    expect(find.text('Zoom 100%'), findsOneWidget);
   });
 
   testWidgets('keeps insert actions enabled with default measure context', (
@@ -370,7 +395,7 @@ Offset _symbolCenterOffset(
   required int symbolIndex,
 }) {
   const measuresPerRow = 4;
-  const minMeasureWidth = 140.0;
+  const minMeasureWidth = 220.0;
   const rowHeight = 140.0;
   const padding = EdgeInsets.all(16);
 


### PR DESCRIPTION
### Motivation
- Provide a visual, draggable symbol palette for inserting notation symbols into the editor to improve symbol insertion UX.
- Integrate the palette into the editor layout so it is available in both landscape and portrait modes.
- Add and adjust widget tests to cover the new palette and account for duplicated label widgets.

### Description
- Add a new widget `SymbolPalette` implemented in `lib/features/editor/presentation/widgets/symbol_palette.dart` that renders a horizontal, scrollable palette of seven draggable symbol items and paints simple symbol visuals with a custom painter.
- Integrate the palette into `EditorShellScreen` by composing a `notationWithPalette` column and replacing `notationPanel` usage with `notationWithPalette` in both landscape and portrait layouts in `lib/features/editor/presentation/editor_shell_screen.dart`.
- Update tests in `test/features/editor/presentation/editor_shell_screen_test.dart` to import the palette, relax some search expectations to `findsWidgets` for repeated labels, and add a new test `renders draggable symbol palette with seven items` which asserts the palette presence and that there are seven `LongPressDraggable<PaletteDragData>` items.

### Testing
- Ran widget tests in `test/features/editor/presentation/editor_shell_screen_test.dart` including `renders editor shell sections and action buttons`, `renders draggable symbol palette with seven items`, and `keeps insert actions enabled with default measure context`. These tests completed and passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce34ddfb008320ae32acd4d3648411)