### PR TITLE
Refine drag-and-drop notation preview behavior

### DIFF
--- a/lib/core/widgets/score_notation/score_notation_painter.dart
+++ b/lib/core/widgets/score_notation/score_notation_painter.dart
@@ -23,6 +23,7 @@ class ScoreNotationPainter extends CustomPainter {
     this.selectedSymbolIndex,
     this.dragFeedback,
     this.insertionTarget,
+    this.insertionPreviewGlyph,
   });
 
   /// All parts — one inner list per part, each containing that part's measures.
@@ -37,6 +38,7 @@ class ScoreNotationPainter extends CustomPainter {
   final int? selectedSymbolIndex;
   final NotationDragFeedback? dragFeedback;
   final NotationInsertTarget? insertionTarget;
+  final NotationPreviewGlyph? insertionPreviewGlyph;
 
   static const double staffLineSpacing = 12;
   static const double tapTargetSize = 24;
@@ -323,6 +325,7 @@ class ScoreNotationPainter extends CustomPainter {
     required double staffBottom,
     required String clefSign,
   }) {
+    final middleLineY = staffTop + staffLineSpacing * 2;
     final insertTarget = insertionTarget;
     if (insertTarget != null && insertTarget.measureIndex == absoluteMeasureIndex) {
       final linePaint = Paint()
@@ -336,6 +339,19 @@ class ScoreNotationPainter extends CustomPainter {
         Offset(x, staffBottom + 8),
         linePaint,
       );
+      final previewGlyph = insertionPreviewGlyph;
+      if (previewGlyph != null) {
+        _drawInsertionPreview(
+          canvas,
+          glyph: previewGlyph,
+          x: x,
+          target: insertTarget,
+          staffTop: staffTop,
+          staffBottom: staffBottom,
+          middleLineY: middleLineY,
+          clefSign: clefSign,
+        );
+      }
     }
 
     if (measure.symbols.isEmpty) return;
@@ -346,7 +362,6 @@ class ScoreNotationPainter extends CustomPainter {
       12.0,
       (measureEndX - measureStartX) - (innerPadding * 2),
     );
-    final middleLineY = staffTop + staffLineSpacing * 2;
     final drag = dragFeedback;
     final hasDragInMeasure =
         drag != null &&
@@ -418,6 +433,76 @@ class ScoreNotationPainter extends CustomPainter {
       ..color = const Color(0xFFD4A96A).withValues(alpha: 0.26)
       ..style = PaintingStyle.fill;
     canvas.drawCircle(center, radius, paint);
+  }
+
+  void _drawInsertionPreview(
+    Canvas canvas, {
+    required NotationPreviewGlyph glyph,
+    required double x,
+    required NotationInsertTarget target,
+    required double staffTop,
+    required double staffBottom,
+    required double middleLineY,
+    required String clefSign,
+  }) {
+    final previewPaint = Paint()
+      ..color = const Color(0xFF2563EB).withValues(alpha: 0.24)
+      ..style = PaintingStyle.fill;
+    final y = switch (glyph) {
+      NotationPreviewGlyph.wholeRest => staffTop + (staffLineSpacing * 3) + 4.3,
+      NotationPreviewGlyph.halfRest => staffTop + (staffLineSpacing * 2) - 3.0,
+      NotationPreviewGlyph.quarterRest => staffTop + (staffLineSpacing * 1.35) + 8.0,
+      _ => StaffPitchMapper.yForPitch(
+          step: target.step,
+          octave: target.octave,
+          bottomLineY: staffBottom,
+          lineSpacing: staffLineSpacing,
+          clefSign: clefSign,
+        ),
+    };
+    _drawSelectionHighlight(canvas, Offset(x, y), radius: 15);
+    canvas.drawCircle(Offset(x, y), 15, previewPaint);
+
+    switch (glyph) {
+      case NotationPreviewGlyph.wholeNote:
+        _drawNote(
+          canvas,
+          const Note(step: 'B', octave: 4, duration: 8, type: 'whole'),
+          x: x,
+          y: y,
+          middleLineY: middleLineY,
+        );
+      case NotationPreviewGlyph.halfNote:
+        _drawNote(
+          canvas,
+          const Note(step: 'B', octave: 4, duration: 4, type: 'half'),
+          x: x,
+          y: y,
+          middleLineY: middleLineY,
+        );
+      case NotationPreviewGlyph.quarterNote:
+        _drawNote(
+          canvas,
+          const Note(step: 'B', octave: 4, duration: 2, type: 'quarter'),
+          x: x,
+          y: y,
+          middleLineY: middleLineY,
+        );
+      case NotationPreviewGlyph.eighthNote:
+        _drawNote(
+          canvas,
+          const Note(step: 'B', octave: 4, duration: 1, type: 'eighth'),
+          x: x,
+          y: y,
+          middleLineY: middleLineY,
+        );
+      case NotationPreviewGlyph.wholeRest:
+        _drawRest(canvas, const Rest(duration: 8, type: 'whole'), x: x, staffTop: staffTop);
+      case NotationPreviewGlyph.halfRest:
+        _drawRest(canvas, const Rest(duration: 4, type: 'half'), x: x, staffTop: staffTop);
+      case NotationPreviewGlyph.quarterRest:
+        _drawRest(canvas, const Rest(duration: 2, type: 'quarter'), x: x, staffTop: staffTop);
+    }
   }
 
   void _drawNote(
@@ -729,8 +814,19 @@ class ScoreNotationPainter extends CustomPainter {
         oldDelegate.selectedMeasureIndex != selectedMeasureIndex ||
         oldDelegate.selectedSymbolIndex != selectedSymbolIndex ||
         oldDelegate.dragFeedback != dragFeedback ||
-        oldDelegate.insertionTarget != insertionTarget;
+        oldDelegate.insertionTarget != insertionTarget ||
+        oldDelegate.insertionPreviewGlyph != insertionPreviewGlyph;
   }
+}
+
+enum NotationPreviewGlyph {
+  wholeNote,
+  halfNote,
+  quarterNote,
+  eighthNote,
+  wholeRest,
+  halfRest,
+  quarterRest,
 }
 
 class NotationSymbolTarget {

--- a/lib/core/widgets/score_notation_viewer.dart
+++ b/lib/core/widgets/score_notation_viewer.dart
@@ -29,6 +29,7 @@ class ScoreNotationViewer extends StatefulWidget {
     this.onSymbolReorder,
     this.canAcceptExternalDrop,
     this.onExternalDrop,
+    this.externalPreviewResolver,
   });
 
   final Score? score;
@@ -49,6 +50,7 @@ class ScoreNotationViewer extends StatefulWidget {
   final ValueChanged<NotationSymbolReorder>? onSymbolReorder;
   final bool Function(Object data)? canAcceptExternalDrop;
   final void Function(NotationInsertTarget target, Object data)? onExternalDrop;
+  final NotationPreviewGlyph? Function(Object data)? externalPreviewResolver;
 
   @override
   State<ScoreNotationViewer> createState() => _ScoreNotationViewerState();
@@ -60,6 +62,7 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
       const NotationLayoutCalculator();
   _NotationDragSession? _dragSession;
   NotationInsertTarget? _externalInsertTarget;
+  NotationPreviewGlyph? _externalPreviewGlyph;
 
   @override
   void dispose() {
@@ -96,19 +99,31 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
         if (widget.canAcceptExternalDrop?.call(data) == false) return;
         final adjusted = _adjustForHorizontalScroll(position);
         final target = _resolveInsertTarget(allParts: allParts, layout: layout, position: adjusted);
-        if (target == _externalInsertTarget) return;
-        setState(() => _externalInsertTarget = target);
+        final previewGlyph = target == null ? null : widget.externalPreviewResolver?.call(data);
+        if (target == _externalInsertTarget && previewGlyph == _externalPreviewGlyph) return;
+        setState(() {
+          _externalInsertTarget = target;
+          _externalPreviewGlyph = previewGlyph;
+        });
       },
       onExternalDragLeave: () {
-        if (_externalInsertTarget == null) return;
-        setState(() => _externalInsertTarget = null);
+        if (_externalInsertTarget == null && _externalPreviewGlyph == null) return;
+        setState(() {
+          _externalInsertTarget = null;
+          _externalPreviewGlyph = null;
+        });
       },
       onExternalAccept: (position, data) {
         if (widget.canAcceptExternalDrop?.call(data) == false) return;
         final adjusted = _adjustForHorizontalScroll(position);
         final target = _resolveInsertTarget(allParts: allParts, layout: layout, position: adjusted);
         if (target != null) widget.onExternalDrop?.call(target, data);
-        if (_externalInsertTarget != null) setState(() => _externalInsertTarget = null);
+        if (_externalInsertTarget != null || _externalPreviewGlyph != null) {
+          setState(() {
+            _externalInsertTarget = null;
+            _externalPreviewGlyph = null;
+          });
+        }
       },
       onTapUp: (widget.onSymbolTap == null && widget.onInsertTap == null)
           ? null
@@ -166,6 +181,7 @@ class _ScoreNotationViewerState extends State<ScoreNotationViewer> {
                 dragX: _dragSession!.dragPosition.dx,
               ),
         insertionTarget: _externalInsertTarget,
+        insertionPreviewGlyph: _externalPreviewGlyph,
       ),
     );
   }

--- a/lib/features/editor/presentation/editor_shell_screen.dart
+++ b/lib/features/editor/presentation/editor_shell_screen.dart
@@ -569,6 +569,7 @@ class _NotationArea extends StatelessWidget {
                           selectedSymbolIndex: editorState.selectedSymbolIndex,
                           insertMode: insertMode,
                           canAcceptExternalDrop: (data) => data is PaletteDragData,
+                          externalPreviewResolver: _previewGlyphForDragData,
                           onExternalDrop: onExternalDrop,
                           onSymbolTap: insertMode ? null : onSymbolTap,
                           onInsertTap: insertMode ? onInsertTap : null,
@@ -645,6 +646,19 @@ class _NotationArea extends StatelessWidget {
         PaletteSymbolType.halfRest => 'half rest',
         PaletteSymbolType.quarterRest => 'quarter rest',
       };
+
+  NotationPreviewGlyph? _previewGlyphForDragData(Object data) {
+    if (data is! PaletteDragData) return null;
+    return switch (data.type) {
+      PaletteSymbolType.wholeNote => NotationPreviewGlyph.wholeNote,
+      PaletteSymbolType.halfNote => NotationPreviewGlyph.halfNote,
+      PaletteSymbolType.quarterNote => NotationPreviewGlyph.quarterNote,
+      PaletteSymbolType.eighthNote => NotationPreviewGlyph.eighthNote,
+      PaletteSymbolType.wholeRest => NotationPreviewGlyph.wholeRest,
+      PaletteSymbolType.halfRest => NotationPreviewGlyph.halfRest,
+      PaletteSymbolType.quarterRest => NotationPreviewGlyph.quarterRest,
+    };
+  }
 }
 
 class _FloatingControls extends StatelessWidget {

--- a/lib/features/editor/presentation/widgets/symbol_palette.dart
+++ b/lib/features/editor/presentation/widgets/symbol_palette.dart
@@ -85,11 +85,18 @@ class _PaletteDraggableItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final core = _PaletteVisual(item: item, isSelected: isSelected);
+    final dragFeedback = CustomPaint(
+      size: const Size(34, 40),
+      painter: _PaletteSymbolPainter(
+        type: item.type,
+        color: _paletteSymbolSelected,
+      ),
+    );
     return LongPressDraggable<PaletteDragData>(
       data: PaletteDragData(type: item.type),
       feedback: Material(
         color: Colors.transparent,
-        child: Transform.scale(scale: 1.5, child: core),
+        child: Transform.scale(scale: 1.7, child: dragFeedback),
       ),
       childWhenDragging: Opacity(opacity: 0.28, child: core),
       child: GestureDetector(onTap: onTap, child: core),


### PR DESCRIPTION
### Motivation
- Improve the palette drag UX so the dragged item is just the music glyph (no surrounding tile/label) and provide a staff-aware hover preview showing where a dragged symbol would be inserted when near the stave.

### Description
- Change drag feedback in `SymbolPalette` so `LongPressDraggable.feedback` shows only a `CustomPaint` glyph instead of the full palette tile.
- Add external drag preview plumbing to `ScoreNotationViewer` with `externalPreviewResolver` and state (`_externalInsertTarget`, `_externalPreviewGlyph`) to resolve and track a preview glyph while hovering over valid insertion targets.
- Extend `ScoreNotationPainter` to accept `insertionPreviewGlyph` (new `NotationPreviewGlyph` enum) and render a highlighted preview glyph aligned to staff pitch or rest position next to the insertion indicator line via `_drawInsertionPreview`.
- Wire the editor UI in `_NotationArea` to map `PaletteDragData` to `NotationPreviewGlyph` with `_previewGlyphForDragData` so hovered previews match the dragged symbol type.

### Testing
- Attempted static analysis with `flutter analyze` but it could not run in this environment (`flutter: command not found`).
- Attempted static analysis with `dart analyze` but it could not run in this environment (`dart: command not found`).
- No automated unit tests were executed in this environment due to missing SDK binaries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c5b0fb808320838d658a49312753)